### PR TITLE
Publish sbom along with other artifacts

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -10,6 +10,8 @@ docstrings.style = Asterisk
 # This also seems more idiomatic to include whitespace in import x.{ yyy }
 spaces.inImportCurlyBraces = true
 
+rewrite.trailingCommas.style = keep
+
 align.tokens."+" = [
   {
     code   = "%"

--- a/src/main/scala/io/github/siculo/sbtbom/BomSbtPlugin.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/BomSbtPlugin.scala
@@ -2,8 +2,9 @@ package io.github.siculo.sbtbom
 
 import io.github.siculo.sbtbom.PluginConstants._
 import org.cyclonedx.model.Component
-import sbt.Keys.{ artifact, configuration, version }
+import sbt.Keys.{ artifact, configuration, packagedArtifacts, version }
 import sbt.{ Def, _ }
+import sbt.plugins.JvmPlugin
 
 import scala.language.postfixOps
 
@@ -12,7 +13,7 @@ import scala.language.postfixOps
  */
 object BomSbtPlugin extends AutoPlugin {
 
-  override def requires: Plugins = empty
+  override def requires: Plugins = JvmPlugin
 
   override def trigger: PluginTrigger = allRequirements
 
@@ -51,7 +52,10 @@ object BomSbtPlugin extends AutoPlugin {
       IntegrationTest / listBom := Def
         .taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, IntegrationTest))
         .value,
-      bomConfigurations := Def.taskDyn(BomSbtSettings.bomConfigurationTask((configuration ?).value)).value
+      bomConfigurations := Def.taskDyn(BomSbtSettings.bomConfigurationTask((configuration ?).value)).value,
+      packagedArtifacts += {
+        Artifact(artifact.value.name, "cyclonedx", "xml", "cyclonedx") -> makeBom.value
+      },
     )
   }
 }


### PR DESCRIPTION
This produces artifact names consistent with the Maven plugin, e.g. `pekko-actor_2.13-cylonedx.xml`

Implements #54

I'd have liked to add a scripted test, but it seems scripted doesn't allow referring to '$HOME' or '~' for checking files have been created.