### PR TITLE
Add and apply scalafmt

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,23 @@
+name: Scalafmt
+
+permissions: {}
+
+on:
+  pull_request:
+    branches: ['**']
+
+jobs:
+  build:
+    name: Code is formatted
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check project is formatted
+        uses: jrouly/scalafmt-native-action@v4
+        with:
+          arguments: '--list --mode diff-ref=origin/main'

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,26 @@
+version = 3.8.3
+runner.dialect = scala212
+maxColumn = 120
+project.git = true
+
+# http://docs.scala-lang.org/style/scaladoc.html recommends the JavaDoc style.
+# scala/scala is written that way too https://github.com/scala/scala/blob/v2.12.2/src/library/scala/Predef.scala
+docstrings.style = Asterisk
+
+# This also seems more idiomatic to include whitespace in import x.{ yyy }
+spaces.inImportCurlyBraces = true
+
+align.tokens."+" = [
+  {
+    code   = "%"
+    owners = [
+      { regex = "Term.ApplyInfix" }
+    ]
+  },
+  {
+    code   = "%%"
+    owners = [
+      { regex = "Term.ApplyInfix" }
+    ]
+  }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,11 @@ lazy val root = (project in file("."))
     sbtPlugin := true,
     libraryDependencies ++= Dependencies.library,
     scriptedLaunchOpts := {
-      scriptedLaunchOpts.value ++ Seq("-Xmx1024M", "-Dplugin.version=" + version.value, "-Dplugin.organization=" + organization.value)
+      scriptedLaunchOpts.value ++ Seq(
+        "-Xmx1024M",
+        "-Dplugin.version=" + version.value,
+        "-Dplugin.organization=" + organization.value
+      )
     },
     scriptedBufferLog := false,
     dependencyOverrides += "org.typelevel" %% "jawn-parser" % "0.14.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 
 object Dependencies {
   lazy val library = Seq(
-    "org.cyclonedx" % "cyclonedx-core-java" % "7.1.0",
-    "org.scalatest" %% "scalatest" % "3.2.9" % Test,
-    "org.scalamock" %% "scalamock" % "5.1.0" % Test
+    "org.cyclonedx"  % "cyclonedx-core-java" % "7.1.0",
+    "org.scalatest" %% "scalatest"           % "3.2.9" % Test,
+    "org.scalamock" %% "scalamock"           % "5.1.0" % Test
   )
 }

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -18,9 +18,11 @@ object Project {
     )
 
   lazy val scmInfo: Option[ScmInfo] =
-    Some(ScmInfo(
-      url("https://github.com/siculo/sbt-bom/tree/master"),
-      "scm:git:git://github.com/siculo/sbt-bom.git",
-      Some("scm:git:ssh://github.com:siculo/sbt-bom.git")
-    ))
+    Some(
+      ScmInfo(
+        url("https://github.com/siculo/sbt-bom/tree/master"),
+        "scm:git:git://github.com/siculo/sbt-bom.git",
+        Some("scm:git:ssh://github.com:siculo/sbt-bom.git")
+      )
+    )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")

--- a/src/main/scala/io/github/siculo/sbtbom/BomExtractor.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/BomExtractor.scala
@@ -2,7 +2,7 @@ package io.github.siculo.sbtbom
 
 import com.github.packageurl.PackageURL
 import org.cyclonedx.CycloneDxSchema
-import org.cyclonedx.model.{Bom, Component, License, LicenseChoice}
+import org.cyclonedx.model.{ Bom, Component, License, LicenseChoice }
 import sbt.librarymanagement.ModuleReport
 import sbt._
 
@@ -24,9 +24,8 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, log: Logg
   }
 
   private def components: Seq[Component] =
-    configurationsForComponents(settings.configuration).foldLeft(Seq[Component]()) {
-      case (collected, configuration) =>
-        collected ++ componentsForConfiguration(configuration)
+    configurationsForComponents(settings.configuration).foldLeft(Seq[Component]()) { case (collected, configuration) =>
+      collected ++ componentsForConfiguration(configuration)
     }
 
   private def configurationsForComponents(configuration: Configuration): Seq[sbt.Configuration] = {
@@ -50,13 +49,13 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, log: Logg
   }
 
   private def componentsForConfiguration(configuration: Configuration): Seq[Component] = {
-    (report.configuration(configuration) map {
-      configurationReport =>
-        log.info(s"Configuration name = ${configurationReport.configuration.name}, modules: ${configurationReport.modules.size}")
-        configurationReport.modules.map {
-          module =>
-            new ComponentExtractor(module).component
-        }
+    (report.configuration(configuration) map { configurationReport =>
+      log.info(
+        s"Configuration name = ${configurationReport.configuration.name}, modules: ${configurationReport.modules.size}"
+      )
+      configurationReport.modules.map { module =>
+        new ComponentExtractor(module).component
+      }
     }).getOrElse(Seq())
   }
 
@@ -98,22 +97,20 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, log: Logg
     }
 
     private def licenseChoice: Option[LicenseChoice] = {
-      val licenses: Seq[model.License] = moduleReport.licenses.map {
-        case (name, mayBeUrl) =>
-          model.License(name, mayBeUrl)
+      val licenses: Seq[model.License] = moduleReport.licenses.map { case (name, mayBeUrl) =>
+        model.License(name, mayBeUrl)
       }
       if (licenses.isEmpty)
         None
       else {
         val choice = new LicenseChoice()
-        licenses.foreach {
-          modelLicense =>
-            val license = new License()
-            license.setName(modelLicense.name)
-            if (settings.schemaVersion != CycloneDxSchema.Version.VERSION_10) {
-              modelLicense.url.foreach(license.setUrl)
-            }
-            choice.addLicense(license)
+        licenses.foreach { modelLicense =>
+          val license = new License()
+          license.setName(modelLicense.name)
+          if (settings.schemaVersion != CycloneDxSchema.Version.VERSION_10) {
+            modelLicense.url.foreach(license.setUrl)
+          }
+          choice.addLicense(license)
         }
         Some(choice)
       }
@@ -121,8 +118,7 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, log: Logg
   }
 
   private def logComponent(component: Component): Unit = {
-    log.info(
-      s""""
+    log.info(s""""
          |${component.getGroup}" % "${component.getName}" % "${component.getVersion}",
          | Modified = ${component.getModified}, Component type = ${component.getType.getTypeName},
          | Scope = ${component.getScope.getScopeName}

--- a/src/main/scala/io/github/siculo/sbtbom/BomExtractorParams.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/BomExtractorParams.scala
@@ -3,5 +3,4 @@ package io.github.siculo.sbtbom
 import org.cyclonedx.CycloneDxSchema
 import sbt.Configuration
 
-case class BomExtractorParams(schemaVersion: CycloneDxSchema.Version,
-                              configuration: Configuration)
+case class BomExtractorParams(schemaVersion: CycloneDxSchema.Version, configuration: Configuration)

--- a/src/main/scala/io/github/siculo/sbtbom/BomSbtPlugin.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/BomSbtPlugin.scala
@@ -2,8 +2,8 @@ package io.github.siculo.sbtbom
 
 import io.github.siculo.sbtbom.PluginConstants._
 import org.cyclonedx.model.Component
-import sbt.Keys.{artifact, configuration, version}
-import sbt.{Def, _}
+import sbt.Keys.{ artifact, configuration, version }
+import sbt.{ Def, _ }
 
 import scala.language.postfixOps
 
@@ -18,13 +18,16 @@ object BomSbtPlugin extends AutoPlugin {
 
   object autoImport {
     lazy val bomFileName: SettingKey[String] = settingKey[String]("bom file name")
-    lazy val bomSchemaVersion: SettingKey[String] = settingKey[String](s"bom schema version; must be one of ${supportedVersionsDescr}; default is ${defaultSupportedVersionDescr}")
+    lazy val bomSchemaVersion: SettingKey[String] = settingKey[String](
+      s"bom schema version; must be one of ${supportedVersionsDescr}; default is ${defaultSupportedVersionDescr}"
+    )
     lazy val makeBom: TaskKey[sbt.File] = taskKey[sbt.File]("Generates bom file")
     lazy val listBom: TaskKey[String] = taskKey[String]("Returns the bom")
     lazy val components: TaskKey[Component] = taskKey[Component]("Returns the bom")
 
-
-    lazy val bomConfigurations: TaskKey[Seq[Configuration]] = taskKey[Seq[Configuration]]("Returns the list of configurations whose components are included in the generated bom")
+    lazy val bomConfigurations: TaskKey[Seq[Configuration]] = taskKey[Seq[Configuration]](
+      "Returns the list of configurations whose components are included in the generated bom"
+    )
   }
 
   import autoImport._
@@ -42,8 +45,12 @@ object BomSbtPlugin extends AutoPlugin {
       listBom := Def.taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, Compile)).value,
       Test / makeBom := Def.taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, Test)).value,
       Test / listBom := Def.taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, Test)).value,
-      IntegrationTest / makeBom := Def.taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, IntegrationTest)).value,
-      IntegrationTest / listBom := Def.taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, IntegrationTest)).value,
+      IntegrationTest / makeBom := Def
+        .taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, IntegrationTest))
+        .value,
+      IntegrationTest / listBom := Def
+        .taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, IntegrationTest))
+        .value,
       bomConfigurations := Def.taskDyn(BomSbtSettings.bomConfigurationTask((configuration ?).value)).value
     )
   }

--- a/src/main/scala/io/github/siculo/sbtbom/BomSbtSettings.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/BomSbtSettings.scala
@@ -1,16 +1,17 @@
 package io.github.siculo.sbtbom
 
 import io.github.siculo.sbtbom.BomSbtPlugin.autoImport._
-import sbt.Keys.{sLog, target}
+import sbt.Keys.{ sLog, target }
 import sbt._
 
 object BomSbtSettings {
-  def makeBomTask(report: UpdateReport, currentConfiguration: Configuration): Def.Initialize[Task[sbt.File]] = Def.task[File] {
-    new MakeBomTask(
-      BomTaskProperties(report, currentConfiguration, sLog.value, bomSchemaVersion.value),
-      target.value / (currentConfiguration / bomFileName).value
-    ).execute
-  }
+  def makeBomTask(report: UpdateReport, currentConfiguration: Configuration): Def.Initialize[Task[sbt.File]] =
+    Def.task[File] {
+      new MakeBomTask(
+        BomTaskProperties(report, currentConfiguration, sLog.value, bomSchemaVersion.value),
+        target.value / (currentConfiguration / bomFileName).value
+      ).execute
+    }
 
   def listBomTask(report: UpdateReport, currentConfiguration: Configuration): Def.Initialize[Task[String]] =
     Def.task[String] {

--- a/src/main/scala/io/github/siculo/sbtbom/BomTask.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/BomTask.scala
@@ -4,13 +4,18 @@ import io.github.siculo.sbtbom.PluginConstants._
 import org.apache.commons.io.FileUtils
 import org.cyclonedx.model.Bom
 import org.cyclonedx.parsers.XmlParser
-import org.cyclonedx.{BomGeneratorFactory, CycloneDxSchema}
+import org.cyclonedx.{ BomGeneratorFactory, CycloneDxSchema }
 import sbt._
 
 import java.nio.charset.Charset
 import scala.collection.JavaConverters._
 
-case class BomTaskProperties(report: UpdateReport, currentConfiguration: Configuration, log: Logger, schemaVersion: String)
+case class BomTaskProperties(
+    report: UpdateReport,
+    currentConfiguration: Configuration,
+    log: Logger,
+    schemaVersion: String
+)
 
 abstract class BomTask[T](protected val properties: BomTaskProperties) {
 
@@ -32,11 +37,11 @@ abstract class BomTask[T](protected val properties: BomTaskProperties) {
     val parser = new XmlParser()
     val exceptions = parser.validate(bomFile, schemaVersion).asScala
     if (exceptions.nonEmpty) {
-      val message = s"The BOM file ${bomFile.getAbsolutePath} does not conform to the CycloneDX BOM standard as defined by the XSD"
+      val message =
+        s"The BOM file ${bomFile.getAbsolutePath} does not conform to the CycloneDX BOM standard as defined by the XSD"
       log.error(s"$message:")
-      exceptions.foreach {
-        exception =>
-          log.error(s"- ${exception.getMessage}")
+      exceptions.foreach { exception =>
+        log.error(s"- ${exception.getMessage}")
       }
       throw new BomError(message)
     }

--- a/src/main/scala/io/github/siculo/sbtbom/MakeBomTask.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/MakeBomTask.scala
@@ -2,9 +2,7 @@ package io.github.siculo.sbtbom
 
 import sbt._
 
-class MakeBomTask(properties: BomTaskProperties,
-                  bomFile: File)
-  extends BomTask[File](properties) {
+class MakeBomTask(properties: BomTaskProperties, bomFile: File) extends BomTask[File](properties) {
 
   override def execute: File = {
     log.info(s"Creating bom file ${bomFile.getAbsolutePath}")
@@ -15,4 +13,3 @@ class MakeBomTask(properties: BomTaskProperties,
     bomFile
   }
 }
-

--- a/src/main/scala/io/github/siculo/sbtbom/PluginConstants.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/PluginConstants.scala
@@ -12,7 +12,10 @@ object PluginConstants {
   )
   val defaultSupportedVersion = CycloneDxSchema.Version.VERSION_10
   val supportedVersionsDescr: String = {
-    supportedVersions.take(supportedVersions.size - 1).map(schemaVersionDescr).mkString(", ") + " or " + schemaVersionDescr(supportedVersions.last)
+    supportedVersions
+      .take(supportedVersions.size - 1)
+      .map(schemaVersionDescr)
+      .mkString(", ") + " or " + schemaVersionDescr(supportedVersions.last)
   }
   val defaultSupportedVersionDescr: String = schemaVersionDescr(defaultSupportedVersion)
 

--- a/src/main/scala/io/github/siculo/sbtbom/licenses/License.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/licenses/License.scala
@@ -1,5 +1,3 @@
 package io.github.siculo.sbtbom.licenses
 
-case class License(id: Option[String] = None,
-                   name: Option[String] = None,
-                   references: Seq[String] = Seq())
+case class License(id: Option[String] = None, name: Option[String] = None, references: Seq[String] = Seq())

--- a/src/main/scala/io/github/siculo/sbtbom/licenses/LicensesArchive.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/licenses/LicensesArchive.scala
@@ -3,12 +3,10 @@ package io.github.siculo.sbtbom.licenses
 import scala.io.Source
 
 class LicensesArchive(licenses: Seq[License]) {
-  private val licensesByUrl: Map[String, License] = licenses.foldLeft(Map[String, License]()) {
-    (map, license) =>
-      map ++ license.references.foldLeft(Map[String, License]()) {
-        (map, ref) =>
-          map + (ref -> license)
-      }
+  private val licensesByUrl: Map[String, License] = licenses.foldLeft(Map[String, License]()) { (map, license) =>
+    map ++ license.references.foldLeft(Map[String, License]()) { (map, ref) =>
+      map + (ref -> license)
+    }
   }
 
   def findByUrl(url: String): Option[License] = licensesByUrl.get(url)

--- a/src/main/scala/io/github/siculo/sbtbom/model/Module.scala
+++ b/src/main/scala/io/github/siculo/sbtbom/model/Module.scala
@@ -1,13 +1,13 @@
 package io.github.siculo.sbtbom.model
 
-import org.cyclonedx.model.Component.{Scope, Type}
+import org.cyclonedx.model.Component.{ Scope, Type }
 
 case class Module(
-                   group: String,
-                   name: String,
-                   version: String,
-                   modified: Boolean,
-                   componentType: Type,
-                   componentScope: Scope,
-                   licenses: Seq[License]
-                 )
+    group: String,
+    name: String,
+    version: String,
+    modified: Boolean,
+    componentType: Type,
+    componentScope: Scope,
+    licenses: Seq[License]
+)

--- a/src/sbt-test/bomfile/bomname/project/Dependencies.scala
+++ b/src/sbt-test/bomfile/bomname/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
 
   lazy val library = Seq(
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion,
+    "org.scalatest" %% "scalatest"     % scalatestVersion % Test
   )
 
 }

--- a/src/sbt-test/bomfile/exists/project/Dependencies.scala
+++ b/src/sbt-test/bomfile/exists/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
 
   lazy val library = Seq(
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion,
+    "org.scalatest" %% "scalatest"     % scalatestVersion % Test
   )
 
 }

--- a/src/sbt-test/dependencies/compile/build.sbt
+++ b/src/sbt-test/dependencies/compile/build.sbt
@@ -7,11 +7,13 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Dependencies.library,
     bomFileName := "bom.xml",
     scalaVersion := "2.12.8",
-    check := Def.sequential(
-      Compile / clean,
-      Compile / compile,
-      checkTask
-    ).value
+    check := Def
+      .sequential(
+        Compile / clean,
+        Compile / compile,
+        checkTask
+      )
+      .value
   )
 
 lazy val check = taskKey[Unit]("check")

--- a/src/sbt-test/dependencies/compile/project/Dependencies.scala
+++ b/src/sbt-test/dependencies/compile/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
 
   lazy val library = Seq(
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion,
+    "org.scalatest" %% "scalatest"     % scalatestVersion % Test
   )
 
 }

--- a/src/sbt-test/dependencies/integrationTest/build.sbt
+++ b/src/sbt-test/dependencies/integrationTest/build.sbt
@@ -7,11 +7,13 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Dependencies.library,
     IntegrationTest / bomFileName := "bom.xml",
     scalaVersion := "2.12.8",
-    check := Def.sequential(
-      Compile / clean,
-      Compile / compile,
-      checkTask
-    ).value
+    check := Def
+      .sequential(
+        Compile / clean,
+        Compile / compile,
+        checkTask
+      )
+      .value
   )
 
 lazy val check = taskKey[Unit]("check")

--- a/src/sbt-test/dependencies/integrationTest/project/Dependencies.scala
+++ b/src/sbt-test/dependencies/integrationTest/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
 
   lazy val library = Seq(
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion,
+    "org.scalatest" %% "scalatest"     % scalatestVersion % Test
   )
 
 }

--- a/src/sbt-test/dependencies/test/build.sbt
+++ b/src/sbt-test/dependencies/test/build.sbt
@@ -7,11 +7,13 @@ lazy val root = (project in file("."))
     libraryDependencies ++= Dependencies.library,
     Test / bomFileName := "bom.xml",
     scalaVersion := "2.12.8",
-    check := Def.sequential(
-      Compile / clean,
-      Compile / compile,
-      checkTask
-    ).value
+    check := Def
+      .sequential(
+        Compile / clean,
+        Compile / compile,
+        checkTask
+      )
+      .value
   )
 
 lazy val check = taskKey[Unit]("check")

--- a/src/sbt-test/dependencies/test/project/Dependencies.scala
+++ b/src/sbt-test/dependencies/test/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
 
   lazy val library = Seq(
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion,
+    "org.scalatest" %% "scalatest"     % scalatestVersion % Test
   )
 
 }

--- a/src/sbt-test/schemaVersion/unsupported/build.sbt
+++ b/src/sbt-test/schemaVersion/unsupported/build.sbt
@@ -8,11 +8,13 @@ lazy val root = (project in file("."))
     Test / bomFileName := "bom.xml",
     scalaVersion := "2.12.8",
     bomSchemaVersion := "999",
-    check := Def.sequential(
-      Compile / clean,
-      Compile / compile,
-      checkTask
-    ).value
+    check := Def
+      .sequential(
+        Compile / clean,
+        Compile / compile,
+        checkTask
+      )
+      .value
   )
 
 lazy val check = taskKey[Unit]("check")

--- a/src/sbt-test/schemaVersion/unsupported/project/Dependencies.scala
+++ b/src/sbt-test/schemaVersion/unsupported/project/Dependencies.scala
@@ -6,10 +6,10 @@ object Dependencies {
   private val scalatestVersion = "3.0.5"
 
   lazy val library = Seq(
-    "io.circe" %% "circe-core" % circeVersion,
-    "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion,
-    "org.scalatest" %% "scalatest" % scalatestVersion % Test,
+    "io.circe"      %% "circe-core"    % circeVersion,
+    "io.circe"      %% "circe-generic" % circeVersion,
+    "io.circe"      %% "circe-parser"  % circeVersion,
+    "org.scalatest" %% "scalatest"     % scalatestVersion % Test
   )
 
 }

--- a/src/test/scala/io/github/siculo/sbtbom/LicensesArchiveSpec.scala
+++ b/src/test/scala/io/github/siculo/sbtbom/LicensesArchiveSpec.scala
@@ -2,11 +2,11 @@ package io.github.siculo.sbtbom
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import io.github.siculo.sbtbom.licenses.{LicensesArchive, LicensesArchiveParser}
+import io.github.siculo.sbtbom.licenses.{ LicensesArchive, LicensesArchiveParser }
 
 class LicensesArchiveSpec extends AnyWordSpec with Matchers {
   "LicensesArchiveParser" should {
-    "fail parsing a not valid archive"  in {
+    "fail parsing a not valid archive" in {
       new LicensesArchiveParser("").isValid shouldBe false
     }
 
@@ -20,7 +20,6 @@ class LicensesArchiveSpec extends AnyWordSpec with Matchers {
       val register = new LicensesArchive(new LicensesArchiveParser(xml).licenses)
       register.findByUrl("http://www.domain.com/missingLicense") shouldBe None
     }
-
 
     "find licenses by ref" in {
       val register = new LicensesArchive(new LicensesArchiveParser(xml).licenses)


### PR DESCRIPTION
This PR adds scalafmt, as well as a github action check as well as applying it to the codebase.

When merging the PR, either do a merge commit or a rebase and merge but not squash and merge as I want to add the `Apply scalafmt` commit to git blame ignore revs.

I used a scalafmt configuration that is common within sbt-plugins