### PR TITLE
Add scala steward configuration

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
In preperation for adding this plugin to scala steward, the current configuration pins the scala version to 2.12 so that we only get updates for patch series of 2.12