### PR TITLE
Generate the latest supported CycloneDX version by default

### DIFF
--- a/src/main/scala/com/github/sbt/sbom/PluginConstants.scala
+++ b/src/main/scala/com/github/sbt/sbom/PluginConstants.scala
@@ -3,14 +3,8 @@ package com.github.sbt.sbom
 import org.cyclonedx.Version
 
 object PluginConstants {
-  val supportedVersions: Seq[Version] = Seq(
-    Version.VERSION_10,
-    Version.VERSION_11,
-    Version.VERSION_12,
-    Version.VERSION_13,
-    Version.VERSION_14
-  )
-  val defaultSupportedVersion = Version.VERSION_10
+  val supportedVersions: Seq[Version] = Version.values()
+  val defaultSupportedVersion: Version = supportedVersions.last
   val supportedVersionsDescr: String = {
     supportedVersions
       .take(supportedVersions.size - 1)

--- a/src/sbt-test/dependencies/compile/build.sbt
+++ b/src/sbt-test/dependencies/compile/build.sbt
@@ -20,13 +20,7 @@ lazy val check = taskKey[Unit]("check")
 lazy val checkTask = Def.task {
   val s: TaskStreams = streams.value
   s.log.info("Verifying bom content...")
-  val bomFile = makeBom.value
-  val context = thisProject.value
-  val expected = XML.loadFile(file(s"${context.base}/etc/bom.xml"))
-  s.log.info(s"${bomFile.getPath}")
-  val actual = XML.loadFile(bomFile)
-  val expectedComponents = expected \ "components"
-  val actualComponents = actual \ "components"
-  require(expectedComponents == actualComponents, s"${context.id} is failed.")
-  s.log.info(s"${bomFile.getPath} content verified")
+  makeBom.value
+  import scala.sys.process._
+  require(Seq("diff", "-w", "target/bom.xml", s"${thisProject.value.base}/etc/bom.xml").! == 0)
 }

--- a/src/sbt-test/dependencies/compile/etc/bom.xml
+++ b/src/sbt-test/dependencies/compile/etc/bom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.0">
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
   <components>
     <component type="library">
       <group>org.scala-lang</group>
@@ -9,6 +9,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
@@ -22,6 +23,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
@@ -35,6 +37,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
@@ -48,6 +51,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
@@ -61,6 +65,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
@@ -74,6 +79,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
@@ -87,6 +93,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
@@ -100,6 +107,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
@@ -113,6 +121,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
@@ -126,6 +135,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
@@ -139,6 +149,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
@@ -152,6 +163,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
@@ -165,6 +177,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
@@ -178,6 +191,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>

--- a/src/sbt-test/dependencies/integrationTest/build.sbt
+++ b/src/sbt-test/dependencies/integrationTest/build.sbt
@@ -21,12 +21,8 @@ lazy val checkTask = Def.task {
   val s: TaskStreams = streams.value
   s.log.info("Verifying bom content...")
   val bomFile = (IntegrationTest / makeBom).value
-  val context = thisProject.value
-  val expected = XML.loadFile(file(s"${context.base}/etc/bom.xml"))
-  s.log.info(s"${bomFile.getPath}")
-  val actual = XML.loadFile(bomFile)
-  val expectedComponents = expected \ "components"
-  val actualComponents = actual \ "components"
-  require(expectedComponents == actualComponents, s"${context.id} is failed.")
+
+  import scala.sys.process._
+  require(Seq("diff", "-w", bomFile.getPath, s"${thisProject.value.base}/etc/bom.xml").! == 0)
   s.log.info(s"${bomFile.getPath} content verified")
 }

--- a/src/sbt-test/dependencies/integrationTest/etc/bom.xml
+++ b/src/sbt-test/dependencies/integrationTest/etc/bom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.0">
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
   <components>
     <component type="library">
       <group>org.scala-lang</group>
@@ -9,6 +9,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
@@ -22,6 +23,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
@@ -35,6 +37,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
@@ -48,6 +51,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
@@ -61,6 +65,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
@@ -74,6 +79,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
@@ -87,6 +93,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
@@ -100,6 +107,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
@@ -113,6 +121,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
@@ -126,6 +135,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
@@ -139,6 +149,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
@@ -152,6 +163,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
@@ -165,6 +177,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
@@ -178,6 +191,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>
@@ -191,6 +205,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
@@ -204,6 +219,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
@@ -217,6 +233,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
@@ -230,6 +247,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
@@ -243,6 +261,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
@@ -256,6 +275,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
@@ -269,6 +289,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
@@ -282,6 +303,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
@@ -295,6 +317,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
@@ -308,6 +331,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
@@ -321,6 +345,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
@@ -334,6 +359,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
@@ -347,6 +373,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
@@ -360,6 +387,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>

--- a/src/sbt-test/dependencies/test/build.sbt
+++ b/src/sbt-test/dependencies/test/build.sbt
@@ -21,12 +21,8 @@ lazy val checkTask = Def.task {
   val s: TaskStreams = streams.value
   s.log.info("Verifying bom content...")
   val bomFile = (Test / makeBom).value
-  val context = thisProject.value
-  val expected = XML.loadFile(file(s"${context.base}/etc/bom.xml"))
-  s.log.info(s"${bomFile.getPath}")
-  val actual = XML.loadFile(bomFile)
-  val expectedComponents = expected \ "components"
-  val actualComponents = actual \ "components"
-  require(expectedComponents == actualComponents, s"${context.id} is failed.")
+
+  import scala.sys.process._
+  require(Seq("diff", "-w", bomFile.getPath, s"${thisProject.value.base}/etc/bom.xml").! == 0)
   s.log.info(s"${bomFile.getPath} content verified")
 }

--- a/src/sbt-test/dependencies/test/etc/bom.xml
+++ b/src/sbt-test/dependencies/test/etc/bom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.0">
+<bom version="1" xmlns="http://cyclonedx.org/schema/bom/1.6">
   <components>
     <component type="library">
       <group>org.scala-lang</group>
@@ -9,6 +9,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
@@ -22,6 +23,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
@@ -35,6 +37,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
@@ -48,6 +51,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
@@ -61,6 +65,7 @@
       <licenses>
         <license>
           <name>the Apache License, ASL Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scalatest/scalatest_2.12@3.0.5</purl>
@@ -74,6 +79,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
@@ -87,6 +93,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
@@ -100,6 +107,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
@@ -113,6 +121,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
@@ -126,6 +135,7 @@
       <licenses>
         <license>
           <name>the Apache License, ASL Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scalactic/scalactic_2.12@3.0.5</purl>
@@ -139,6 +149,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>
@@ -152,6 +163,7 @@
       <licenses>
         <license>
           <name>BSD 3-clause</name>
+          <url>http://opensource.org/licenses/BSD-3-Clause</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.6</purl>
@@ -165,6 +177,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
@@ -178,6 +191,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
@@ -191,6 +205,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
@@ -204,6 +219,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
@@ -217,6 +233,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
@@ -230,6 +247,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
@@ -243,6 +261,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
@@ -256,6 +275,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
@@ -269,6 +289,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
@@ -282,6 +303,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
@@ -295,6 +317,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
@@ -308,6 +331,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
@@ -321,6 +345,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
@@ -334,6 +359,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
@@ -347,6 +373,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
@@ -360,6 +387,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
@@ -373,6 +401,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
@@ -386,6 +415,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
@@ -399,6 +429,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>
@@ -412,6 +443,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
@@ -425,6 +457,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
@@ -438,6 +471,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
@@ -451,6 +485,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
@@ -464,6 +499,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
@@ -477,6 +513,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
@@ -490,6 +527,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
@@ -503,6 +541,7 @@
       <licenses>
         <license>
           <name>Apache 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
@@ -516,6 +555,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
@@ -529,6 +569,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
@@ -542,6 +583,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
@@ -555,6 +597,7 @@
       <licenses>
         <license>
           <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
@@ -568,6 +611,7 @@
       <licenses>
         <license>
           <name>MIT</name>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
@@ -581,6 +625,7 @@
       <licenses>
         <license>
           <name>Apache-2.0</name>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>

--- a/src/test/scala/com/github/sbt/sbom/PluginConstantsSpec.scala
+++ b/src/test/scala/com/github/sbt/sbom/PluginConstantsSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.wordspec.AnyWordSpec
 class PluginConstantsSpec extends AnyWordSpec with Matchers {
   "PluginConstants" should {
     "return the description of the supported versions" in {
-      PluginConstants.supportedVersionsDescr shouldBe """"1.0", "1.1", "1.2", "1.3" or "1.4""""
+      PluginConstants.supportedVersionsDescr shouldBe """"1.0", "1.1", "1.2", "1.3", "1.4", "1.5" or "1.6""""
     }
   }
 }


### PR DESCRIPTION
Support all versions supported by the cyclonedx library.

Use 'diff' in the scripted test to get more useful output on failures.

~Draft because the serialNumber is not reproducible - needs #71 first~

Fixes #17