### PR TITLE
Disable serial number by default

### DIFF
--- a/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
@@ -16,7 +16,7 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, log: Logg
 
   def bom: Bom = {
     val bom = new Bom
-    if (settings.schemaVersion != Version.VERSION_10) {
+    if (settings.includeBomSerialNumber && settings.schemaVersion != Version.VERSION_10) {
       bom.setSerialNumber(serialNumber)
     }
     bom.setComponents(components.asJava)

--- a/src/main/scala/com/github/sbt/sbom/BomExtractorParams.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractorParams.scala
@@ -3,4 +3,8 @@ package com.github.sbt.sbom
 import org.cyclonedx.Version
 import sbt.Configuration
 
-case class BomExtractorParams(schemaVersion: Version, configuration: Configuration)
+case class BomExtractorParams(
+    schemaVersion: Version,
+    configuration: Configuration,
+    includeBomSerialNumber: Boolean,
+)

--- a/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
@@ -22,6 +22,9 @@ object BomSbtPlugin extends AutoPlugin {
     lazy val bomSchemaVersion: SettingKey[String] = settingKey[String](
       s"bom schema version; must be one of ${supportedVersionsDescr}; default is ${defaultSupportedVersionDescr}"
     )
+    lazy val includeBomSerialNumber: SettingKey[Boolean] = settingKey[Boolean](
+      "should the resulting BOM contain a serial number? default is false, because the current mechanism for determining the serial number is not reproducible"
+    )
     lazy val makeBom: TaskKey[sbt.File] = taskKey[sbt.File]("Generates bom file")
     lazy val listBom: TaskKey[String] = taskKey[String]("Returns the bom")
     lazy val components: TaskKey[Component] = taskKey[Component]("Returns the bom")
@@ -42,6 +45,7 @@ object BomSbtPlugin extends AutoPlugin {
     Seq(
       bomFileName := bomFileNameSetting.value,
       bomSchemaVersion := defaultSupportedVersion.getVersionString,
+      includeBomSerialNumber := false,
       makeBom := Def.taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, Compile)).value,
       listBom := Def.taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, Compile)).value,
       Test / makeBom := Def.taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, Test)).value,

--- a/src/main/scala/com/github/sbt/sbom/BomSbtSettings.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtSettings.scala
@@ -8,14 +8,28 @@ object BomSbtSettings {
   def makeBomTask(report: UpdateReport, currentConfiguration: Configuration): Def.Initialize[Task[sbt.File]] =
     Def.task[File] {
       new MakeBomTask(
-        BomTaskProperties(report, currentConfiguration, sLog.value, bomSchemaVersion.value),
+        BomTaskProperties(
+          report,
+          currentConfiguration,
+          sLog.value,
+          bomSchemaVersion.value,
+          includeBomSerialNumber.value
+        ),
         target.value / (currentConfiguration / bomFileName).value
       ).execute
     }
 
   def listBomTask(report: UpdateReport, currentConfiguration: Configuration): Def.Initialize[Task[String]] =
     Def.task[String] {
-      new ListBomTask(BomTaskProperties(report, currentConfiguration, sLog.value, bomSchemaVersion.value)).execute
+      new ListBomTask(
+        BomTaskProperties(
+          report,
+          currentConfiguration,
+          sLog.value,
+          bomSchemaVersion.value,
+          includeBomSerialNumber.value
+        )
+      ).execute
     }
 
   def bomConfigurationTask(currentConfiguration: Option[Configuration]): Def.Initialize[Task[Seq[Configuration]]] =

--- a/src/main/scala/com/github/sbt/sbom/BomTask.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomTask.scala
@@ -15,7 +15,8 @@ case class BomTaskProperties(
     report: UpdateReport,
     currentConfiguration: Configuration,
     log: Logger,
-    schemaVersion: String
+    schemaVersion: String,
+    includeBomSerialNumber: Boolean,
 )
 
 abstract class BomTask[T](protected val properties: BomTaskProperties) {
@@ -55,7 +56,7 @@ abstract class BomTask[T](protected val properties: BomTaskProperties) {
   }
 
   private def extractorParams(currentConfiguration: Configuration): BomExtractorParams =
-    BomExtractorParams(schemaVersion, currentConfiguration)
+    BomExtractorParams(schemaVersion, currentConfiguration, includeBomSerialNumber)
 
   private def getXmlText(bom: Bom): String = {
     val bomGenerator = BomGeneratorFactory.createXml(schemaVersion, bom)
@@ -84,4 +85,6 @@ abstract class BomTask[T](protected val properties: BomTaskProperties) {
         log.error(message)
         throw new BomError(message)
     }
+
+  protected lazy val includeBomSerialNumber: Boolean = properties.includeBomSerialNumber
 }


### PR DESCRIPTION
As it's not generated in a reproducible way.

The `includeBomSerialNumber` parameter is also found in the Maven plugin.