### PR TITLE
Set scriptedSbt lowest support sbt version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         scala: [2.12.20]
-        java: [temurin@8, temurin@11, temurin@17, temurin@21]
+        java: [temurin@8, temurin@11, temurin@17]
         exclude:
           - java: temurin@8
             os: macos-latest
@@ -70,14 +70,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: sbt
-
-      - name: Setup Java (temurin@21)
-        if: matrix.java == 'temurin@21'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
           cache: sbt
 
       - name: Setup sbt
@@ -150,14 +142,6 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
-          cache: sbt
-
-      - name: Setup Java (temurin@21)
-        if: matrix.java == 'temurin@21'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 21
           cache: sbt
 
       - name: Setup sbt

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Add the plugin dependency to the file `project/plugins.sbt` using `addSbtPlugin`
 
 `addSbtPlugin("io.github.siculo" %% "sbt-bom" % "0.3.0")`
 
+Note that the minimum supported version of sbt is 1.5.2 (this is what the [scripted](https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html#scripted+test+framework) tests target)
+
 ### BOM creation
 
 To create the bom for the default configuration use `makeBom` command:

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val root = (project in file("."))
       )
     },
     scriptedBufferLog := false,
-    scriptedSbt := "1.10.2",
+    scriptedSbt := "1.5.2",
     dependencyOverrides += "org.typelevel" %% "jawn-parser" % "0.14.1"
   )
 
@@ -59,8 +59,7 @@ ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest", "windows-
 ThisBuild / githubWorkflowJavaVersions := Seq(
   JavaSpec.temurin("8"),
   JavaSpec.temurin("11"),
-  JavaSpec.temurin("17"),
-  JavaSpec.temurin("21")
+  JavaSpec.temurin("17")
 )
 
 ThisBuild / githubWorkflowBuildMatrixExclusions += MatrixExclude(Map("java" -> "temurin@8", "os" -> "macos-latest"))


### PR DESCRIPTION
This PR sets scripted sbt version to the lowest version of sbt that still passes the tests. Note that if we implement some feature that requires a newer version of sbt we can always just increase this value, all this PR does is set the lowest version of sbt that we can reasonably claim we support.

I had to remove JDK 21 from the build matrix but this is due to an sbt internal detail (specifically older versions of sbt don't work with newer jdk's beause of sbt internals but this is not relevant for sbt plugins, this plugin will still support newer JDK's than 17).