### PR TITLE
chore: document that we still expect to make API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ lazy val root = (project in file("."))
 
 This plugin supports the CycloneDX XML and JSON BOM formats.
 
+## Stability
+
+We believe this plugin is stable enough to be used in production, but
+we do not yet promise API stability: you may need to make configuration
+changes or encounter changed behaviour when updating the plugin.
+
 ## Contributing
 
 ### testing


### PR DESCRIPTION
We'll likely want to refactor the task structure when we implement #90 or #91, it might be nice to explicitly set expectations around this without making it a blocker for doing earlier releases.