### PR TITLE
Add explicit license headers

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
+
 # scalafmt
 b182120910a953913c4149d2776150384a6dff81

--- a/.github/workflows/license-headers.yml
+++ b/.github/workflows/license-headers.yml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2022 Free Software Foundation Europe e.V. <https://fsfe.org>
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  reuse-compliance-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: REUSE Compliance Check
+      uses: fsfe/reuse-action@v5

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
+
 updates.pin = [
   { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
 ]

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Fabrizio Di Giuseppe
+Copyright (c) the sbt-sbom team
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSES/CC0-1.0.txt
+++ b/LICENSES/CC0-1.0.txt
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, including 
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell 
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the 
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT 
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO 
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER 
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE 
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: The sbt-sbom team
+
+SPDX-License-Identifier: MIT
+-->
+
 # sbt-sbom
 
 *sbt SBOM exporter*

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,28 @@
+version=1
+
+[[annotations]]
+path = [
+  ".gitignore",
+  ".scalafix.conf",
+  ".scalafmt.conf",
+
+  ".github/workflows/clean.yml",
+  ".github/workflows/ci.yml",
+  ".github/workflows/dependency-graph.yml",
+  ".github/workflows/format.yml",
+
+  "project/build.properties",
+
+  "src/main/resources/licenses.readme.md",
+
+  "src/test/resources/*.txt",
+  "src/sbt-test/*/*/etc/bom.json",
+  "src/sbt-test/*/*/etc/bom.xml",
+]
+SPDX-FileCopyrightText = "the sbt-sbom team"
+SPDX-License-Identifier = "CC0-1.0"
+
+[[annotations]]
+path = [ "src/main/resources/licenses.json", ]
+SPDX-FileCopyrightText = "SPDX Workgroup"
+SPDX-License-Identifier = "Apache-2.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 ThisBuild / organization := Organization.organization
 ThisBuild / organizationName := Organization.organizationName
 ThisBuild / organizationHomepage := Organization.organizationHomepage

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/project/Organization.scala
+++ b/project/Organization.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt.url
 
 object Organization {

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Project {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"      % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.9.2")

--- a/src/main/resources/licenses.about.md
+++ b/src/main/resources/licenses.about.md
@@ -1,4 +1,0 @@
-The file "licenses.json" in this directory is distributed
-by SPDX Workgroup (https://spdx.org/) under terms and
-conditions of the following license:
-https://github.com/spdx/LicenseListPublisher/blob/master/LICENSE

--- a/src/main/scala/com/github/sbt/sbom/BomError.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomError.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 class BomError(message: String) extends Exception(message)

--- a/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import com.github.packageurl.PackageURL

--- a/src/main/scala/com/github/sbt/sbom/BomExtractorParams.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractorParams.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import org.cyclonedx.Version

--- a/src/main/scala/com/github/sbt/sbom/BomFormat.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomFormat.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import com.github.sbt.sbom.PluginConstants.supportedVersions

--- a/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import com.github.sbt.sbom.PluginConstants._

--- a/src/main/scala/com/github/sbt/sbom/BomSbtSettings.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtSettings.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import com.github.sbt.sbom.BomSbtPlugin.autoImport._

--- a/src/main/scala/com/github/sbt/sbom/BomTask.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomTask.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import com.github.sbt.sbom.PluginConstants._

--- a/src/main/scala/com/github/sbt/sbom/ListBomTask.scala
+++ b/src/main/scala/com/github/sbt/sbom/ListBomTask.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 class ListBomTask(properties: BomTaskProperties) extends BomTask[String](properties) {

--- a/src/main/scala/com/github/sbt/sbom/MakeBomTask.scala
+++ b/src/main/scala/com/github/sbt/sbom/MakeBomTask.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import sbt._

--- a/src/main/scala/com/github/sbt/sbom/PluginConstants.scala
+++ b/src/main/scala/com/github/sbt/sbom/PluginConstants.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import org.cyclonedx.Version

--- a/src/main/scala/com/github/sbt/sbom/licenses/License.scala
+++ b/src/main/scala/com/github/sbt/sbom/licenses/License.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom.licenses
 
 final case class License(id: String, name: String, references: Seq[String])

--- a/src/main/scala/com/github/sbt/sbom/licenses/LicensesArchive.scala
+++ b/src/main/scala/com/github/sbt/sbom/licenses/LicensesArchive.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom.licenses
 
 import com.github.sbt.sbom.licenses.LicensesArchive.{ normalizeId, normalizeUrl }

--- a/src/main/scala/com/github/sbt/sbom/licenses/LicensesArchiveJsonParser.scala
+++ b/src/main/scala/com/github/sbt/sbom/licenses/LicensesArchiveJsonParser.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom.licenses
 
 import io.circe.Decoder

--- a/src/main/scala/com/github/sbt/sbom/model/License.scala
+++ b/src/main/scala/com/github/sbt/sbom/model/License.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom.model
 
 final case class License(name: String, url: Option[String])

--- a/src/main/scala/com/github/sbt/sbom/model/Module.scala
+++ b/src/main/scala/com/github/sbt/sbom/model/Module.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom.model
 
 import org.cyclonedx.model.Component.{ Scope, Type }

--- a/src/sbt-test/bomfile/bomname/build.sbt
+++ b/src/sbt-test/bomfile/bomname/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/bomfile/bomname/project/Dependencies.scala
+++ b/src/sbt-test/bomfile/bomname/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/bomfile/bomname/project/plugins.sbt
+++ b/src/sbt-test/bomfile/bomname/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/bomfile/bomname/test
+++ b/src/sbt-test/bomfile/bomname/test
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > clean
 > compile
 > makeBom

--- a/src/sbt-test/bomfile/exists/build.sbt
+++ b/src/sbt-test/bomfile/exists/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "exists",

--- a/src/sbt-test/bomfile/exists/project/Dependencies.scala
+++ b/src/sbt-test/bomfile/exists/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/bomfile/exists/project/plugins.sbt
+++ b/src/sbt-test/bomfile/exists/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/bomfile/exists/test
+++ b/src/sbt-test/bomfile/exists/test
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > clean
 > compile
 > makeBom

--- a/src/sbt-test/dependencies/compile/build.sbt
+++ b/src/sbt-test/dependencies/compile/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/dependencies/compile/project/Dependencies.scala
+++ b/src/sbt-test/dependencies/compile/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/dependencies/compile/project/plugins.sbt
+++ b/src/sbt-test/dependencies/compile/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/dependencies/compile/test
+++ b/src/sbt-test/dependencies/compile/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > check

--- a/src/sbt-test/dependencies/integrationTest/build.sbt
+++ b/src/sbt-test/dependencies/integrationTest/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/dependencies/integrationTest/project/Dependencies.scala
+++ b/src/sbt-test/dependencies/integrationTest/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/dependencies/integrationTest/project/plugins.sbt
+++ b/src/sbt-test/dependencies/integrationTest/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/dependencies/integrationTest/test
+++ b/src/sbt-test/dependencies/integrationTest/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > check

--- a/src/sbt-test/dependencies/test/build.sbt
+++ b/src/sbt-test/dependencies/test/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/dependencies/test/project/Dependencies.scala
+++ b/src/sbt-test/dependencies/test/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/dependencies/test/project/plugins.sbt
+++ b/src/sbt-test/dependencies/test/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/dependencies/test/test
+++ b/src/sbt-test/dependencies/test/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > check

--- a/src/sbt-test/dependenciesJson/compile/build.sbt
+++ b/src/sbt-test/dependenciesJson/compile/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/dependenciesJson/compile/project/Dependencies.scala
+++ b/src/sbt-test/dependenciesJson/compile/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/dependenciesJson/compile/project/plugins.sbt
+++ b/src/sbt-test/dependenciesJson/compile/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/dependenciesJson/compile/test
+++ b/src/sbt-test/dependenciesJson/compile/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > check

--- a/src/sbt-test/dependenciesJson/integrationTest/build.sbt
+++ b/src/sbt-test/dependenciesJson/integrationTest/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/dependenciesJson/integrationTest/project/Dependencies.scala
+++ b/src/sbt-test/dependenciesJson/integrationTest/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/dependenciesJson/integrationTest/project/plugins.sbt
+++ b/src/sbt-test/dependenciesJson/integrationTest/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/dependenciesJson/integrationTest/test
+++ b/src/sbt-test/dependenciesJson/integrationTest/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > check

--- a/src/sbt-test/dependenciesJson/test/build.sbt
+++ b/src/sbt-test/dependenciesJson/test/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 lazy val root = (project in file("."))
   .settings(
     name := "dependencies",

--- a/src/sbt-test/dependenciesJson/test/project/Dependencies.scala
+++ b/src/sbt-test/dependenciesJson/test/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/dependenciesJson/test/project/plugins.sbt
+++ b/src/sbt-test/dependenciesJson/test/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/dependenciesJson/test/test
+++ b/src/sbt-test/dependenciesJson/test/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 > check

--- a/src/sbt-test/schemaVersion/unsupported/build.sbt
+++ b/src/sbt-test/schemaVersion/unsupported/build.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt.Keys._
 
 lazy val root = (project in file("."))

--- a/src/sbt-test/schemaVersion/unsupported/project/Dependencies.scala
+++ b/src/sbt-test/schemaVersion/unsupported/project/Dependencies.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 import sbt._
 
 object Dependencies {

--- a/src/sbt-test/schemaVersion/unsupported/project/plugins.sbt
+++ b/src/sbt-test/schemaVersion/unsupported/project/plugins.sbt
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 (
   sys.props.get("plugin.version"),
   sys.props.get("plugin.organization")

--- a/src/sbt-test/schemaVersion/unsupported/test
+++ b/src/sbt-test/schemaVersion/unsupported/test
@@ -1,1 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
 -> check

--- a/src/test/scala/com/github/sbt/sbom/LicensesArchiveSpec.scala
+++ b/src/test/scala/com/github/sbt/sbom/LicensesArchiveSpec.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import com.github.sbt.sbom.licenses.LicensesArchive

--- a/src/test/scala/com/github/sbt/sbom/PluginConstantsSpec.scala
+++ b/src/test/scala/com/github/sbt/sbom/PluginConstantsSpec.scala
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
 package com.github.sbt.sbom
 
 import org.scalatest.matchers.should.Matchers


### PR DESCRIPTION
In preparation of including a file with Apache-2.0-licensed code from sbt in https://github.com/sbt/sbt-sbom/pull/109

https://reuse.software/