### PR TITLE
use consistent line endings on all platforms

### DIFF
--- a/src/main/scala/com/github/sbt/sbom/BomTask.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomTask.scala
@@ -32,8 +32,8 @@ abstract class BomTask[T](protected val properties: BomTaskProperties) {
     val params: BomExtractorParams = extractorParams(currentConfiguration)
     val bom: Bom = new BomExtractor(params, report, log).bom
     val bomText: String = bomFormat match {
-      case BomFormat.Json => BomGeneratorFactory.createJson(schemaVersion, bom).toJsonString
-      case BomFormat.Xml  => BomGeneratorFactory.createXml(schemaVersion, bom).toXmlString
+      case BomFormat.Json => BomGeneratorFactory.createJson(schemaVersion, bom).toJsonString.replaceAll("\r?\n", "\n")
+      case BomFormat.Xml  => BomGeneratorFactory.createXml(schemaVersion, bom).toXmlString.replaceAll("\r?\n", "\n")
     }
     logBomInfo(params, bom)
     bomText

--- a/src/sbt-test/dependencies/compile/build.sbt
+++ b/src/sbt-test/dependencies/compile/build.sbt
@@ -22,5 +22,5 @@ lazy val checkTask = Def.task {
   s.log.info("Verifying bom content...")
   makeBom.value
   import scala.sys.process._
-  require(Seq("diff", "-w", "target/bom.xml", s"${thisProject.value.base}/etc/bom.xml").! == 0)
+  require(Seq("diff", "target/bom.xml", s"${thisProject.value.base}/etc/bom.xml").! == 0)
 }

--- a/src/sbt-test/dependencies/integrationTest/build.sbt
+++ b/src/sbt-test/dependencies/integrationTest/build.sbt
@@ -23,6 +23,6 @@ lazy val checkTask = Def.task {
   val bomFile = (IntegrationTest / makeBom).value
 
   import scala.sys.process._
-  require(Seq("diff", "-w", bomFile.getPath, s"${thisProject.value.base}/etc/bom.xml").! == 0)
+  require(Seq("diff", bomFile.getPath, s"${thisProject.value.base}/etc/bom.xml").! == 0)
   s.log.info(s"${bomFile.getPath} content verified")
 }

--- a/src/sbt-test/dependencies/test/build.sbt
+++ b/src/sbt-test/dependencies/test/build.sbt
@@ -23,6 +23,6 @@ lazy val checkTask = Def.task {
   val bomFile = (Test / makeBom).value
 
   import scala.sys.process._
-  require(Seq("diff", "-w", bomFile.getPath, s"${thisProject.value.base}/etc/bom.xml").! == 0)
+  require(Seq("diff", bomFile.getPath, s"${thisProject.value.base}/etc/bom.xml").! == 0)
   s.log.info(s"${bomFile.getPath} content verified")
 }

--- a/src/sbt-test/dependenciesJson/compile/build.sbt
+++ b/src/sbt-test/dependenciesJson/compile/build.sbt
@@ -22,5 +22,5 @@ lazy val checkTask = Def.task {
   s.log.info("Verifying bom content...")
   makeBom.value
   import scala.sys.process._
-  require(Seq("diff", "-w", "target/bom.json", s"${thisProject.value.base}/etc/bom.json").! == 0)
+  require(Seq("diff", "target/bom.json", s"${thisProject.value.base}/etc/bom.json").! == 0)
 }

--- a/src/sbt-test/dependenciesJson/integrationTest/build.sbt
+++ b/src/sbt-test/dependenciesJson/integrationTest/build.sbt
@@ -23,6 +23,6 @@ lazy val checkTask = Def.task {
   val bomFile = (IntegrationTest / makeBom).value
 
   import scala.sys.process._
-  require(Seq("diff", "-w", bomFile.getPath, s"${thisProject.value.base}/etc/bom.json").! == 0)
+  require(Seq("diff", bomFile.getPath, s"${thisProject.value.base}/etc/bom.json").! == 0)
   s.log.info(s"${bomFile.getPath} content verified")
 }

--- a/src/sbt-test/dependenciesJson/test/build.sbt
+++ b/src/sbt-test/dependenciesJson/test/build.sbt
@@ -23,6 +23,6 @@ lazy val checkTask = Def.task {
   val bomFile = (Test / makeBom).value
 
   import scala.sys.process._
-  require(Seq("diff", "-w", bomFile.getPath, s"${thisProject.value.base}/etc/bom.json").! == 0)
+  require(Seq("diff", bomFile.getPath, s"${thisProject.value.base}/etc/bom.json").! == 0)
   s.log.info(s"${bomFile.getPath} content verified")
 }


### PR DESCRIPTION
Should we add a test for this? I have removed the "-w" option on diff but I think it would be better to leave that in because git crlf could be configured differently for different users making it harder for them to run the tests.