### PR TITLE
chore: exclude scripted-sbt from dependency submission

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -15,4 +15,4 @@ jobs:
         uses: sbt/setup-sbt@v1
       - uses: scalacenter/sbt-dependency-submission@v3
         with:
-          configs-ignore: compile-internal optional test
+          configs-ignore: compile-internal optional test scripted-sbt

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,3 @@
-libraryDependencies += "org.scala-sbt"        %% "scripted-plugin" % sbtVersion.value
 addSbtPlugin("org.scalameta"  % "sbt-scalafmt"       % "2.5.2")
 addSbtPlugin("com.eed3si9n"   % "sbt-buildinfo"      % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release"     % "1.9.2")


### PR DESCRIPTION
especially because it refers to ancient versions of things because it uses an old sbt (#110)