### PR TITLE
Update SPDX license list to latest from upstream

### DIFF
--- a/src/main/resources/licenses.json
+++ b/src/main/resources/licenses.json
@@ -1,11 +1,11 @@
 {
-  "licenseListVersion": "d2ce3b6",
+  "licenseListVersion": "f8acf30",
   "licenses": [
     {
       "reference": "https://spdx.org/licenses/0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/0BSD.json",
-      "referenceNumber": 16,
+      "referenceNumber": 500,
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
@@ -18,7 +18,7 @@
       "reference": "https://spdx.org/licenses/3D-Slicer-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/3D-Slicer-1.0.json",
-      "referenceNumber": 46,
+      "referenceNumber": 494,
       "name": "3D Slicer License v1.0",
       "licenseId": "3D-Slicer-1.0",
       "seeAlso": [
@@ -31,7 +31,7 @@
       "reference": "https://spdx.org/licenses/AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AAL.json",
-      "referenceNumber": 604,
+      "referenceNumber": 136,
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
@@ -43,7 +43,7 @@
       "reference": "https://spdx.org/licenses/Abstyles.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": 175,
+      "referenceNumber": 641,
       "name": "Abstyles License",
       "licenseId": "Abstyles",
       "seeAlso": [
@@ -55,7 +55,7 @@
       "reference": "https://spdx.org/licenses/AdaCore-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AdaCore-doc.json",
-      "referenceNumber": 638,
+      "referenceNumber": 406,
       "name": "AdaCore Doc License",
       "licenseId": "AdaCore-doc",
       "seeAlso": [
@@ -69,7 +69,7 @@
       "reference": "https://spdx.org/licenses/Adobe-2006.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": 1,
+      "referenceNumber": 131,
       "name": "Adobe Systems Incorporated Source Code License Agreement",
       "licenseId": "Adobe-2006",
       "seeAlso": [
@@ -81,7 +81,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Display-PostScript.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Display-PostScript.json",
-      "referenceNumber": 592,
+      "referenceNumber": 362,
       "name": "Adobe Display PostScript License",
       "licenseId": "Adobe-Display-PostScript",
       "seeAlso": [
@@ -93,7 +93,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Glyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": 634,
+      "referenceNumber": 510,
       "name": "Adobe Glyph List License",
       "licenseId": "Adobe-Glyph",
       "seeAlso": [
@@ -105,7 +105,7 @@
       "reference": "https://spdx.org/licenses/Adobe-Utopia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Adobe-Utopia.json",
-      "referenceNumber": 118,
+      "referenceNumber": 592,
       "name": "Adobe Utopia Font License",
       "licenseId": "Adobe-Utopia",
       "seeAlso": [
@@ -117,7 +117,7 @@
       "reference": "https://spdx.org/licenses/ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ADSL.json",
-      "referenceNumber": 547,
+      "referenceNumber": 37,
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -129,7 +129,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": 577,
+      "referenceNumber": 426,
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -143,7 +143,7 @@
       "reference": "https://spdx.org/licenses/AFL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": 591,
+      "referenceNumber": 421,
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -157,7 +157,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": 21,
+      "referenceNumber": 356,
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
@@ -170,7 +170,7 @@
       "reference": "https://spdx.org/licenses/AFL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": 5,
+      "referenceNumber": 223,
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -183,7 +183,7 @@
       "reference": "https://spdx.org/licenses/AFL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": 632,
+      "referenceNumber": 116,
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
@@ -197,7 +197,7 @@
       "reference": "https://spdx.org/licenses/Afmparse.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": 223,
+      "referenceNumber": 326,
       "name": "Afmparse License",
       "licenseId": "Afmparse",
       "seeAlso": [
@@ -209,7 +209,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": 262,
+      "referenceNumber": 318,
       "name": "Affero General Public License v1.0",
       "licenseId": "AGPL-1.0",
       "seeAlso": [
@@ -222,7 +222,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": 95,
+      "referenceNumber": 398,
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -234,7 +234,7 @@
       "reference": "https://spdx.org/licenses/AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": 238,
+      "referenceNumber": 438,
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -246,7 +246,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": 121,
+      "referenceNumber": 517,
       "name": "GNU Affero General Public License v3.0",
       "licenseId": "AGPL-3.0",
       "seeAlso": [
@@ -260,7 +260,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": 265,
+      "referenceNumber": 179,
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
@@ -274,7 +274,7 @@
       "reference": "https://spdx.org/licenses/AGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": 667,
+      "referenceNumber": 543,
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
@@ -288,7 +288,7 @@
       "reference": "https://spdx.org/licenses/Aladdin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": 423,
+      "referenceNumber": 67,
       "name": "Aladdin Free Public License",
       "licenseId": "Aladdin",
       "seeAlso": [
@@ -301,7 +301,7 @@
       "reference": "https://spdx.org/licenses/AMD-newlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMD-newlib.json",
-      "referenceNumber": 160,
+      "referenceNumber": 413,
       "name": "AMD newlib License",
       "licenseId": "AMD-newlib",
       "seeAlso": [
@@ -313,7 +313,7 @@
       "reference": "https://spdx.org/licenses/AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": 441,
+      "referenceNumber": 531,
       "name": "AMD\u0027s plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -325,7 +325,7 @@
       "reference": "https://spdx.org/licenses/AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML.json",
-      "referenceNumber": 308,
+      "referenceNumber": 553,
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -337,7 +337,7 @@
       "reference": "https://spdx.org/licenses/AML-glslang.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AML-glslang.json",
-      "referenceNumber": 31,
+      "referenceNumber": 25,
       "name": "AML glslang variant License",
       "licenseId": "AML-glslang",
       "seeAlso": [
@@ -350,7 +350,7 @@
       "reference": "https://spdx.org/licenses/AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": 246,
+      "referenceNumber": 75,
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -362,7 +362,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": 508,
+      "referenceNumber": 456,
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -374,7 +374,7 @@
       "reference": "https://spdx.org/licenses/ANTLR-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ANTLR-PD-fallback.json",
-      "referenceNumber": 582,
+      "referenceNumber": 635,
       "name": "ANTLR Software Rights Notice with license fallback",
       "licenseId": "ANTLR-PD-fallback",
       "seeAlso": [
@@ -386,7 +386,7 @@
       "reference": "https://spdx.org/licenses/any-OSI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/any-OSI.json",
-      "referenceNumber": 363,
+      "referenceNumber": 119,
       "name": "Any OSI License",
       "licenseId": "any-OSI",
       "seeAlso": [
@@ -398,7 +398,7 @@
       "reference": "https://spdx.org/licenses/any-OSI-perl-modules.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/any-OSI-perl-modules.json",
-      "referenceNumber": 108,
+      "referenceNumber": 286,
       "name": "Any OSI License - Perl Modules",
       "licenseId": "any-OSI-perl-modules",
       "seeAlso": [
@@ -412,7 +412,7 @@
       "reference": "https://spdx.org/licenses/Apache-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": 168,
+      "referenceNumber": 348,
       "name": "Apache License 1.0",
       "licenseId": "Apache-1.0",
       "seeAlso": [
@@ -425,7 +425,7 @@
       "reference": "https://spdx.org/licenses/Apache-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": 99,
+      "referenceNumber": 628,
       "name": "Apache License 1.1",
       "licenseId": "Apache-1.1",
       "seeAlso": [
@@ -439,7 +439,7 @@
       "reference": "https://spdx.org/licenses/Apache-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": 345,
+      "referenceNumber": 418,
       "name": "Apache License 2.0",
       "licenseId": "Apache-2.0",
       "seeAlso": [
@@ -453,7 +453,7 @@
       "reference": "https://spdx.org/licenses/APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APAFML.json",
-      "referenceNumber": 138,
+      "referenceNumber": 574,
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -465,7 +465,7 @@
       "reference": "https://spdx.org/licenses/APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": 379,
+      "referenceNumber": 224,
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
@@ -477,7 +477,7 @@
       "reference": "https://spdx.org/licenses/App-s2p.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/App-s2p.json",
-      "referenceNumber": 535,
+      "referenceNumber": 612,
       "name": "App::s2p License",
       "licenseId": "App-s2p",
       "seeAlso": [
@@ -489,7 +489,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": 231,
+      "referenceNumber": 122,
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -502,7 +502,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": 198,
+      "referenceNumber": 383,
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -514,7 +514,7 @@
       "reference": "https://spdx.org/licenses/APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": 153,
+      "referenceNumber": 248,
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -526,7 +526,7 @@
       "reference": "https://spdx.org/licenses/APSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": 456,
+      "referenceNumber": 435,
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -539,7 +539,7 @@
       "reference": "https://spdx.org/licenses/Arphic-1999.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Arphic-1999.json",
-      "referenceNumber": 256,
+      "referenceNumber": 121,
       "name": "Arphic Public License",
       "licenseId": "Arphic-1999",
       "seeAlso": [
@@ -551,7 +551,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": 0,
+      "referenceNumber": 621,
       "name": "Artistic License 1.0",
       "licenseId": "Artistic-1.0",
       "seeAlso": [
@@ -564,7 +564,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": 249,
+      "referenceNumber": 205,
       "name": "Artistic License 1.0 w/clause 8",
       "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
@@ -576,7 +576,7 @@
       "reference": "https://spdx.org/licenses/Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": 672,
+      "referenceNumber": 231,
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -588,7 +588,7 @@
       "reference": "https://spdx.org/licenses/Artistic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": 631,
+      "referenceNumber": 521,
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
@@ -603,7 +603,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.0.json",
-      "referenceNumber": 420,
+      "referenceNumber": 376,
       "name": "ASWF Digital Assets License version 1.0",
       "licenseId": "ASWF-Digital-Assets-1.0",
       "seeAlso": [
@@ -615,7 +615,7 @@
       "reference": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ASWF-Digital-Assets-1.1.json",
-      "referenceNumber": 129,
+      "referenceNumber": 4,
       "name": "ASWF Digital Assets License 1.1",
       "licenseId": "ASWF-Digital-Assets-1.1",
       "seeAlso": [
@@ -627,7 +627,7 @@
       "reference": "https://spdx.org/licenses/Baekmuk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Baekmuk.json",
-      "referenceNumber": 652,
+      "referenceNumber": 433,
       "name": "Baekmuk License",
       "licenseId": "Baekmuk",
       "seeAlso": [
@@ -639,7 +639,7 @@
       "reference": "https://spdx.org/licenses/Bahyph.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": 497,
+      "referenceNumber": 289,
       "name": "Bahyph License",
       "licenseId": "Bahyph",
       "seeAlso": [
@@ -651,7 +651,7 @@
       "reference": "https://spdx.org/licenses/Barr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Barr.json",
-      "referenceNumber": 189,
+      "referenceNumber": 94,
       "name": "Barr License",
       "licenseId": "Barr",
       "seeAlso": [
@@ -663,7 +663,7 @@
       "reference": "https://spdx.org/licenses/bcrypt-Solar-Designer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bcrypt-Solar-Designer.json",
-      "referenceNumber": 620,
+      "referenceNumber": 624,
       "name": "bcrypt Solar Designer License",
       "licenseId": "bcrypt-Solar-Designer",
       "seeAlso": [
@@ -675,7 +675,7 @@
       "reference": "https://spdx.org/licenses/Beerware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Beerware.json",
-      "referenceNumber": 530,
+      "referenceNumber": 428,
       "name": "Beerware License",
       "licenseId": "Beerware",
       "seeAlso": [
@@ -688,7 +688,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Charter.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Charter.json",
-      "referenceNumber": 603,
+      "referenceNumber": 530,
       "name": "Bitstream Charter Font License",
       "licenseId": "Bitstream-Charter",
       "seeAlso": [
@@ -701,7 +701,7 @@
       "reference": "https://spdx.org/licenses/Bitstream-Vera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Bitstream-Vera.json",
-      "referenceNumber": 501,
+      "referenceNumber": 197,
       "name": "Bitstream Vera Font License",
       "licenseId": "Bitstream-Vera",
       "seeAlso": [
@@ -714,7 +714,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": 529,
+      "referenceNumber": 668,
       "name": "BitTorrent Open Source License v1.0",
       "licenseId": "BitTorrent-1.0",
       "seeAlso": [
@@ -726,7 +726,7 @@
       "reference": "https://spdx.org/licenses/BitTorrent-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": 606,
+      "referenceNumber": 583,
       "name": "BitTorrent Open Source License v1.1",
       "licenseId": "BitTorrent-1.1",
       "seeAlso": [
@@ -739,7 +739,7 @@
       "reference": "https://spdx.org/licenses/blessing.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/blessing.json",
-      "referenceNumber": 578,
+      "referenceNumber": 669,
       "name": "SQLite Blessing",
       "licenseId": "blessing",
       "seeAlso": [
@@ -752,7 +752,7 @@
       "reference": "https://spdx.org/licenses/BlueOak-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BlueOak-1.0.0.json",
-      "referenceNumber": 136,
+      "referenceNumber": 191,
       "name": "Blue Oak Model License 1.0.0",
       "licenseId": "BlueOak-1.0.0",
       "seeAlso": [
@@ -764,7 +764,7 @@
       "reference": "https://spdx.org/licenses/Boehm-GC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Boehm-GC.json",
-      "referenceNumber": 311,
+      "referenceNumber": 540,
       "name": "Boehm-Demers-Weiser GC License",
       "licenseId": "Boehm-GC",
       "seeAlso": [
@@ -778,7 +778,7 @@
       "reference": "https://spdx.org/licenses/Boehm-GC-without-fee.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Boehm-GC-without-fee.json",
-      "referenceNumber": 239,
+      "referenceNumber": 604,
       "name": "Boehm-Demers-Weiser GC License (without fee)",
       "licenseId": "Boehm-GC-without-fee",
       "seeAlso": [
@@ -790,7 +790,7 @@
       "reference": "https://spdx.org/licenses/Borceux.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Borceux.json",
-      "referenceNumber": 318,
+      "referenceNumber": 496,
       "name": "Borceux license",
       "licenseId": "Borceux",
       "seeAlso": [
@@ -802,7 +802,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-2-Clause.json",
-      "referenceNumber": 587,
+      "referenceNumber": 582,
       "name": "Brian Gladman 2-Clause License",
       "licenseId": "Brian-Gladman-2-Clause",
       "seeAlso": [
@@ -815,7 +815,7 @@
       "reference": "https://spdx.org/licenses/Brian-Gladman-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Brian-Gladman-3-Clause.json",
-      "referenceNumber": 462,
+      "referenceNumber": 360,
       "name": "Brian Gladman 3-Clause License",
       "licenseId": "Brian-Gladman-3-Clause",
       "seeAlso": [
@@ -827,7 +827,7 @@
       "reference": "https://spdx.org/licenses/BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": 200,
+      "referenceNumber": 101,
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
@@ -839,7 +839,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": 151,
+      "referenceNumber": 61,
       "name": "BSD 2-Clause \"Simplified\" License",
       "licenseId": "BSD-2-Clause",
       "seeAlso": [
@@ -852,7 +852,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Darwin.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Darwin.json",
-      "referenceNumber": 85,
+      "referenceNumber": 299,
       "name": "BSD 2-Clause - Ian Darwin variant",
       "licenseId": "BSD-2-Clause-Darwin",
       "seeAlso": [
@@ -864,7 +864,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-first-lines.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-first-lines.json",
-      "referenceNumber": 96,
+      "referenceNumber": 134,
       "name": "BSD 2-Clause - first lines requirement",
       "licenseId": "BSD-2-Clause-first-lines",
       "seeAlso": [
@@ -877,7 +877,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": 425,
+      "referenceNumber": 382,
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -890,7 +890,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": 24,
+      "referenceNumber": 225,
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -903,7 +903,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": 443,
+      "referenceNumber": 269,
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -915,7 +915,7 @@
       "reference": "https://spdx.org/licenses/BSD-2-Clause-Views.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-2-Clause-Views.json",
-      "referenceNumber": 673,
+      "referenceNumber": 569,
       "name": "BSD 2-Clause with views sentence",
       "licenseId": "BSD-2-Clause-Views",
       "seeAlso": [
@@ -929,7 +929,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": 396,
+      "referenceNumber": 258,
       "name": "BSD 3-Clause \"New\" or \"Revised\" License",
       "licenseId": "BSD-3-Clause",
       "seeAlso": [
@@ -943,7 +943,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-acpica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-acpica.json",
-      "referenceNumber": 367,
+      "referenceNumber": 616,
       "name": "BSD 3-Clause acpica variant",
       "licenseId": "BSD-3-Clause-acpica",
       "seeAlso": [
@@ -955,7 +955,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": 538,
+      "referenceNumber": 511,
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -967,7 +967,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Clear.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": 37,
+      "referenceNumber": 33,
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -980,7 +980,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-flex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-flex.json",
-      "referenceNumber": 641,
+      "referenceNumber": 96,
       "name": "BSD 3-Clause Flex variant",
       "licenseId": "BSD-3-Clause-flex",
       "seeAlso": [
@@ -992,7 +992,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-HP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-HP.json",
-      "referenceNumber": 302,
+      "referenceNumber": 346,
       "name": "Hewlett-Packard BSD variant license",
       "licenseId": "BSD-3-Clause-HP",
       "seeAlso": [
@@ -1004,7 +1004,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": 647,
+      "referenceNumber": 256,
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
@@ -1016,7 +1016,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Modification.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Modification.json",
-      "referenceNumber": 214,
+      "referenceNumber": 489,
       "name": "BSD 3-Clause Modification",
       "licenseId": "BSD-3-Clause-Modification",
       "seeAlso": [
@@ -1028,7 +1028,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Military-License.json",
-      "referenceNumber": 317,
+      "referenceNumber": 100,
       "name": "BSD 3-Clause No Military License",
       "licenseId": "BSD-3-Clause-No-Military-License",
       "seeAlso": [
@@ -1041,7 +1041,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": 384,
+      "referenceNumber": 542,
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -1053,7 +1053,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": 60,
+      "referenceNumber": 184,
       "name": "BSD 3-Clause No Nuclear License 2014",
       "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
       "seeAlso": [
@@ -1065,7 +1065,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": 375,
+      "referenceNumber": 518,
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -1077,7 +1077,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
-      "referenceNumber": 479,
+      "referenceNumber": 107,
       "name": "BSD 3-Clause Open MPI variant",
       "licenseId": "BSD-3-Clause-Open-MPI",
       "seeAlso": [
@@ -1090,7 +1090,7 @@
       "reference": "https://spdx.org/licenses/BSD-3-Clause-Sun.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-3-Clause-Sun.json",
-      "referenceNumber": 395,
+      "referenceNumber": 495,
       "name": "BSD 3-Clause Sun Microsystems",
       "licenseId": "BSD-3-Clause-Sun",
       "seeAlso": [
@@ -1102,7 +1102,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": 391,
+      "referenceNumber": 416,
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -1115,7 +1115,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-Shortened.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-Shortened.json",
-      "referenceNumber": 288,
+      "referenceNumber": 387,
       "name": "BSD 4 Clause Shortened",
       "licenseId": "BSD-4-Clause-Shortened",
       "seeAlso": [
@@ -1127,7 +1127,7 @@
       "reference": "https://spdx.org/licenses/BSD-4-Clause-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": 194,
+      "referenceNumber": 123,
       "name": "BSD-4-Clause (University of California-Specific)",
       "licenseId": "BSD-4-Clause-UC",
       "seeAlso": [
@@ -1139,7 +1139,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3RENO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3RENO.json",
-      "referenceNumber": 633,
+      "referenceNumber": 373,
       "name": "BSD 4.3 RENO License",
       "licenseId": "BSD-4.3RENO",
       "seeAlso": [
@@ -1152,7 +1152,7 @@
       "reference": "https://spdx.org/licenses/BSD-4.3TAHOE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-4.3TAHOE.json",
-      "referenceNumber": 346,
+      "referenceNumber": 355,
       "name": "BSD 4.3 TAHOE License",
       "licenseId": "BSD-4.3TAHOE",
       "seeAlso": [
@@ -1165,7 +1165,7 @@
       "reference": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Advertising-Acknowledgement.json",
-      "referenceNumber": 127,
+      "referenceNumber": 488,
       "name": "BSD Advertising Acknowledgement License",
       "licenseId": "BSD-Advertising-Acknowledgement",
       "seeAlso": [
@@ -1177,7 +1177,7 @@
       "reference": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Attribution-HPND-disclaimer.json",
-      "referenceNumber": 477,
+      "referenceNumber": 44,
       "name": "BSD with Attribution and HPND disclaimer",
       "licenseId": "BSD-Attribution-HPND-disclaimer",
       "seeAlso": [
@@ -1189,7 +1189,7 @@
       "reference": "https://spdx.org/licenses/BSD-Inferno-Nettverk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Inferno-Nettverk.json",
-      "referenceNumber": 27,
+      "referenceNumber": 194,
       "name": "BSD-Inferno-Nettverk",
       "licenseId": "BSD-Inferno-Nettverk",
       "seeAlso": [
@@ -1201,7 +1201,7 @@
       "reference": "https://spdx.org/licenses/BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": 205,
+      "referenceNumber": 546,
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -1213,7 +1213,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-beginning-file.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-beginning-file.json",
-      "referenceNumber": 20,
+      "referenceNumber": 420,
       "name": "BSD Source Code Attribution - beginning of file variant",
       "licenseId": "BSD-Source-beginning-file",
       "seeAlso": [
@@ -1225,7 +1225,7 @@
       "reference": "https://spdx.org/licenses/BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": 260,
+      "referenceNumber": 213,
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -1237,7 +1237,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics.json",
-      "referenceNumber": 276,
+      "referenceNumber": 164,
       "name": "Systemics BSD variant license",
       "licenseId": "BSD-Systemics",
       "seeAlso": [
@@ -1249,7 +1249,7 @@
       "reference": "https://spdx.org/licenses/BSD-Systemics-W3Works.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSD-Systemics-W3Works.json",
-      "referenceNumber": 358,
+      "referenceNumber": 652,
       "name": "Systemics W3Works BSD variant license",
       "licenseId": "BSD-Systemics-W3Works",
       "seeAlso": [
@@ -1261,7 +1261,7 @@
       "reference": "https://spdx.org/licenses/BSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": 364,
+      "referenceNumber": 272,
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
@@ -1275,7 +1275,7 @@
       "reference": "https://spdx.org/licenses/BUSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/BUSL-1.1.json",
-      "referenceNumber": 331,
+      "referenceNumber": 319,
       "name": "Business Source License 1.1",
       "licenseId": "BUSL-1.1",
       "seeAlso": [
@@ -1287,7 +1287,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.5.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": 137,
+      "referenceNumber": 557,
       "name": "bzip2 and libbzip2 License v1.0.5",
       "licenseId": "bzip2-1.0.5",
       "seeAlso": [
@@ -1300,7 +1300,7 @@
       "reference": "https://spdx.org/licenses/bzip2-1.0.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": 161,
+      "referenceNumber": 610,
       "name": "bzip2 and libbzip2 License v1.0.6",
       "licenseId": "bzip2-1.0.6",
       "seeAlso": [
@@ -1314,7 +1314,7 @@
       "reference": "https://spdx.org/licenses/C-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/C-UDA-1.0.json",
-      "referenceNumber": 329,
+      "referenceNumber": 340,
       "name": "Computational Use of Data Agreement v1.0",
       "licenseId": "C-UDA-1.0",
       "seeAlso": [
@@ -1327,7 +1327,7 @@
       "reference": "https://spdx.org/licenses/CAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0.json",
-      "referenceNumber": 675,
+      "referenceNumber": 133,
       "name": "Cryptographic Autonomy License 1.0",
       "licenseId": "CAL-1.0",
       "seeAlso": [
@@ -1340,7 +1340,7 @@
       "reference": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
-      "referenceNumber": 195,
+      "referenceNumber": 660,
       "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
       "licenseId": "CAL-1.0-Combined-Work-Exception",
       "seeAlso": [
@@ -1353,7 +1353,7 @@
       "reference": "https://spdx.org/licenses/Caldera.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera.json",
-      "referenceNumber": 192,
+      "referenceNumber": 345,
       "name": "Caldera License",
       "licenseId": "Caldera",
       "seeAlso": [
@@ -1365,7 +1365,7 @@
       "reference": "https://spdx.org/licenses/Caldera-no-preamble.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Caldera-no-preamble.json",
-      "referenceNumber": 52,
+      "referenceNumber": 615,
       "name": "Caldera License (without preamble)",
       "licenseId": "Caldera-no-preamble",
       "seeAlso": [
@@ -1377,7 +1377,7 @@
       "reference": "https://spdx.org/licenses/Catharon.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Catharon.json",
-      "referenceNumber": 191,
+      "referenceNumber": 396,
       "name": "Catharon License",
       "licenseId": "Catharon",
       "seeAlso": [
@@ -1389,7 +1389,7 @@
       "reference": "https://spdx.org/licenses/CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": 209,
+      "referenceNumber": 83,
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
@@ -1401,7 +1401,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": 310,
+      "referenceNumber": 232,
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
@@ -1413,7 +1413,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": 170,
+      "referenceNumber": 475,
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
@@ -1425,7 +1425,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": 444,
+      "referenceNumber": 519,
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
@@ -1437,7 +1437,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-2.5-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-2.5-AU.json",
-      "referenceNumber": 630,
+      "referenceNumber": 457,
       "name": "Creative Commons Attribution 2.5 Australia",
       "licenseId": "CC-BY-2.5-AU",
       "seeAlso": [
@@ -1449,7 +1449,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": 581,
+      "referenceNumber": 68,
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
@@ -1461,7 +1461,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AT.json",
-      "referenceNumber": 55,
+      "referenceNumber": 130,
       "name": "Creative Commons Attribution 3.0 Austria",
       "licenseId": "CC-BY-3.0-AT",
       "seeAlso": [
@@ -1473,7 +1473,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-AU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-AU.json",
-      "referenceNumber": 8,
+      "referenceNumber": 279,
       "name": "Creative Commons Attribution 3.0 Australia",
       "licenseId": "CC-BY-3.0-AU",
       "seeAlso": [
@@ -1485,7 +1485,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-DE.json",
-      "referenceNumber": 229,
+      "referenceNumber": 89,
       "name": "Creative Commons Attribution 3.0 Germany",
       "licenseId": "CC-BY-3.0-DE",
       "seeAlso": [
@@ -1497,7 +1497,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-IGO.json",
-      "referenceNumber": 568,
+      "referenceNumber": 212,
       "name": "Creative Commons Attribution 3.0 IGO",
       "licenseId": "CC-BY-3.0-IGO",
       "seeAlso": [
@@ -1509,7 +1509,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-NL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-NL.json",
-      "referenceNumber": 250,
+      "referenceNumber": 402,
       "name": "Creative Commons Attribution 3.0 Netherlands",
       "licenseId": "CC-BY-3.0-NL",
       "seeAlso": [
@@ -1521,7 +1521,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-3.0-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-3.0-US.json",
-      "referenceNumber": 635,
+      "referenceNumber": 275,
       "name": "Creative Commons Attribution 3.0 United States",
       "licenseId": "CC-BY-3.0-US",
       "seeAlso": [
@@ -1533,7 +1533,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": 585,
+      "referenceNumber": 493,
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
@@ -1546,7 +1546,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": 432,
+      "referenceNumber": 415,
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
@@ -1559,7 +1559,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": 550,
+      "referenceNumber": 105,
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
@@ -1572,7 +1572,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": 270,
+      "referenceNumber": 332,
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
@@ -1585,7 +1585,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": 234,
+      "referenceNumber": 227,
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
@@ -1598,7 +1598,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-3.0-DE.json",
-      "referenceNumber": 413,
+      "referenceNumber": 204,
       "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
       "licenseId": "CC-BY-NC-3.0-DE",
       "seeAlso": [
@@ -1610,7 +1610,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": 646,
+      "referenceNumber": 455,
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
@@ -1623,7 +1623,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": 348,
+      "referenceNumber": 190,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
@@ -1635,7 +1635,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": 580,
+      "referenceNumber": 243,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
@@ -1647,7 +1647,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": 514,
+      "referenceNumber": 357,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
@@ -1659,7 +1659,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": 43,
+      "referenceNumber": 51,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
@@ -1671,7 +1671,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-DE.json",
-      "referenceNumber": 81,
+      "referenceNumber": 595,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-NC-ND-3.0-DE",
       "seeAlso": [
@@ -1683,7 +1683,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
-      "referenceNumber": 342,
+      "referenceNumber": 108,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
       "licenseId": "CC-BY-NC-ND-3.0-IGO",
       "seeAlso": [
@@ -1695,7 +1695,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": 148,
+      "referenceNumber": 186,
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
@@ -1707,7 +1707,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": 241,
+      "referenceNumber": 649,
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
@@ -1719,7 +1719,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": 224,
+      "referenceNumber": 2,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
@@ -1731,7 +1731,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-DE.json",
-      "referenceNumber": 648,
+      "referenceNumber": 312,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
       "licenseId": "CC-BY-NC-SA-2.0-DE",
       "seeAlso": [
@@ -1743,7 +1743,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-FR.json",
-      "referenceNumber": 187,
+      "referenceNumber": 264,
       "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
       "licenseId": "CC-BY-NC-SA-2.0-FR",
       "seeAlso": [
@@ -1755,7 +1755,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.0-UK.json",
-      "referenceNumber": 411,
+      "referenceNumber": 181,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-NC-SA-2.0-UK",
       "seeAlso": [
@@ -1767,7 +1767,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": 617,
+      "referenceNumber": 69,
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
@@ -1779,7 +1779,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": 583,
+      "referenceNumber": 571,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
@@ -1791,7 +1791,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-DE.json",
-      "referenceNumber": 644,
+      "referenceNumber": 625,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
       "licenseId": "CC-BY-NC-SA-3.0-DE",
       "seeAlso": [
@@ -1803,7 +1803,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-3.0-IGO.json",
-      "referenceNumber": 252,
+      "referenceNumber": 106,
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
       "licenseId": "CC-BY-NC-SA-3.0-IGO",
       "seeAlso": [
@@ -1815,7 +1815,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": 115,
+      "referenceNumber": 484,
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
@@ -1827,7 +1827,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": 489,
+      "referenceNumber": 337,
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
@@ -1840,7 +1840,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": 143,
+      "referenceNumber": 293,
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1853,7 +1853,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": 56,
+      "referenceNumber": 522,
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
@@ -1866,7 +1866,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": 2,
+      "referenceNumber": 630,
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
@@ -1879,7 +1879,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-3.0-DE.json",
-      "referenceNumber": 242,
+      "referenceNumber": 386,
       "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
       "licenseId": "CC-BY-ND-3.0-DE",
       "seeAlso": [
@@ -1891,7 +1891,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": 389,
+      "referenceNumber": 102,
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
@@ -1904,7 +1904,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": 82,
+      "referenceNumber": 581,
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
@@ -1916,7 +1916,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": 102,
+      "referenceNumber": 529,
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
@@ -1928,7 +1928,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
-      "referenceNumber": 70,
+      "referenceNumber": 270,
       "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
       "licenseId": "CC-BY-SA-2.0-UK",
       "seeAlso": [
@@ -1940,7 +1940,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.1-JP.json",
-      "referenceNumber": 336,
+      "referenceNumber": 18,
       "name": "Creative Commons Attribution Share Alike 2.1 Japan",
       "licenseId": "CC-BY-SA-2.1-JP",
       "seeAlso": [
@@ -1952,7 +1952,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": 294,
+      "referenceNumber": 617,
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
@@ -1964,7 +1964,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": 57,
+      "referenceNumber": 62,
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
@@ -1976,7 +1976,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
-      "referenceNumber": 9,
+      "referenceNumber": 532,
       "name": "Creative Commons Attribution Share Alike 3.0 Austria",
       "licenseId": "CC-BY-SA-3.0-AT",
       "seeAlso": [
@@ -1988,7 +1988,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-DE.json",
-      "referenceNumber": 597,
+      "referenceNumber": 183,
       "name": "Creative Commons Attribution Share Alike 3.0 Germany",
       "licenseId": "CC-BY-SA-3.0-DE",
       "seeAlso": [
@@ -2000,7 +2000,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-3.0-IGO.json",
-      "referenceNumber": 83,
+      "referenceNumber": 627,
       "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
       "licenseId": "CC-BY-SA-3.0-IGO",
       "seeAlso": [
@@ -2012,7 +2012,7 @@
       "reference": "https://spdx.org/licenses/CC-BY-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": 58,
+      "referenceNumber": 41,
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
@@ -2025,7 +2025,7 @@
       "reference": "https://spdx.org/licenses/CC-PDDC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-PDDC.json",
-      "referenceNumber": 665,
+      "referenceNumber": 602,
       "name": "Creative Commons Public Domain Dedication and Certification",
       "licenseId": "CC-PDDC",
       "seeAlso": [
@@ -2037,7 +2037,7 @@
       "reference": "https://spdx.org/licenses/CC-PDM-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-PDM-1.0.json",
-      "referenceNumber": 65,
+      "referenceNumber": 565,
       "name": "Creative    Commons Public Domain Mark 1.0 Universal",
       "licenseId": "CC-PDM-1.0",
       "seeAlso": [
@@ -2050,7 +2050,7 @@
       "reference": "https://spdx.org/licenses/CC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC-SA-1.0.json",
-      "referenceNumber": 274,
+      "referenceNumber": 321,
       "name": "Creative Commons Share Alike 1.0 Generic",
       "licenseId": "CC-SA-1.0",
       "seeAlso": [
@@ -2062,7 +2062,7 @@
       "reference": "https://spdx.org/licenses/CC0-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": 372,
+      "referenceNumber": 110,
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
@@ -2075,7 +2075,7 @@
       "reference": "https://spdx.org/licenses/CDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": 350,
+      "referenceNumber": 284,
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
@@ -2088,7 +2088,7 @@
       "reference": "https://spdx.org/licenses/CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": 253,
+      "referenceNumber": 198,
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -2101,7 +2101,7 @@
       "reference": "https://spdx.org/licenses/CDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDL-1.0.json",
-      "referenceNumber": 44,
+      "referenceNumber": 539,
       "name": "Common Documentation License 1.0",
       "licenseId": "CDL-1.0",
       "seeAlso": [
@@ -2115,7 +2115,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": 669,
+      "referenceNumber": 523,
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -2127,7 +2127,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Permissive-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Permissive-2.0.json",
-      "referenceNumber": 486,
+      "referenceNumber": 636,
       "name": "Community Data License Agreement Permissive 2.0",
       "licenseId": "CDLA-Permissive-2.0",
       "seeAlso": [
@@ -2139,7 +2139,7 @@
       "reference": "https://spdx.org/licenses/CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": 499,
+      "referenceNumber": 155,
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -2151,7 +2151,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": 418,
+      "referenceNumber": 46,
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -2163,7 +2163,7 @@
       "reference": "https://spdx.org/licenses/CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": 10,
+      "referenceNumber": 343,
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -2175,7 +2175,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": 405,
+      "referenceNumber": 114,
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -2188,7 +2188,7 @@
       "reference": "https://spdx.org/licenses/CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": 184,
+      "referenceNumber": 153,
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -2200,7 +2200,7 @@
       "reference": "https://spdx.org/licenses/CECILL-B.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": 539,
+      "referenceNumber": 650,
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -2213,7 +2213,7 @@
       "reference": "https://spdx.org/licenses/CECILL-C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": 92,
+      "referenceNumber": 290,
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
@@ -2226,7 +2226,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.1.json",
-      "referenceNumber": 354,
+      "referenceNumber": 347,
       "name": "CERN Open Hardware Licence v1.1",
       "licenseId": "CERN-OHL-1.1",
       "seeAlso": [
@@ -2238,7 +2238,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-1.2.json",
-      "referenceNumber": 459,
+      "referenceNumber": 144,
       "name": "CERN Open Hardware Licence v1.2",
       "licenseId": "CERN-OHL-1.2",
       "seeAlso": [
@@ -2250,7 +2250,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-P-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-P-2.0.json",
-      "referenceNumber": 29,
+      "referenceNumber": 423,
       "name": "CERN Open Hardware Licence Version 2 - Permissive",
       "licenseId": "CERN-OHL-P-2.0",
       "seeAlso": [
@@ -2262,7 +2262,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-S-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-S-2.0.json",
-      "referenceNumber": 624,
+      "referenceNumber": 308,
       "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
       "licenseId": "CERN-OHL-S-2.0",
       "seeAlso": [
@@ -2274,7 +2274,7 @@
       "reference": "https://spdx.org/licenses/CERN-OHL-W-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CERN-OHL-W-2.0.json",
-      "referenceNumber": 613,
+      "referenceNumber": 228,
       "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
       "licenseId": "CERN-OHL-W-2.0",
       "seeAlso": [
@@ -2286,7 +2286,7 @@
       "reference": "https://spdx.org/licenses/CFITSIO.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CFITSIO.json",
-      "referenceNumber": 255,
+      "referenceNumber": 593,
       "name": "CFITSIO License",
       "licenseId": "CFITSIO",
       "seeAlso": [
@@ -2299,7 +2299,7 @@
       "reference": "https://spdx.org/licenses/check-cvs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/check-cvs.json",
-      "referenceNumber": 146,
+      "referenceNumber": 412,
       "name": "check-cvs License",
       "licenseId": "check-cvs",
       "seeAlso": [
@@ -2311,7 +2311,7 @@
       "reference": "https://spdx.org/licenses/checkmk.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/checkmk.json",
-      "referenceNumber": 468,
+      "referenceNumber": 5,
       "name": "Checkmk License",
       "licenseId": "checkmk",
       "seeAlso": [
@@ -2323,7 +2323,7 @@
       "reference": "https://spdx.org/licenses/ClArtistic.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": 97,
+      "referenceNumber": 285,
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -2337,7 +2337,7 @@
       "reference": "https://spdx.org/licenses/Clips.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Clips.json",
-      "referenceNumber": 365,
+      "referenceNumber": 392,
       "name": "Clips License",
       "licenseId": "Clips",
       "seeAlso": [
@@ -2349,7 +2349,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach.json",
-      "referenceNumber": 518,
+      "referenceNumber": 24,
       "name": "CMU Mach License",
       "licenseId": "CMU-Mach",
       "seeAlso": [
@@ -2361,7 +2361,7 @@
       "reference": "https://spdx.org/licenses/CMU-Mach-nodoc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CMU-Mach-nodoc.json",
-      "referenceNumber": 103,
+      "referenceNumber": 262,
       "name": "CMU    Mach - no notices-in-documentation variant",
       "licenseId": "CMU-Mach-nodoc",
       "seeAlso": [
@@ -2374,7 +2374,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Jython.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": 94,
+      "referenceNumber": 274,
       "name": "CNRI Jython License",
       "licenseId": "CNRI-Jython",
       "seeAlso": [
@@ -2386,7 +2386,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": 59,
+      "referenceNumber": 287,
       "name": "CNRI Python License",
       "licenseId": "CNRI-Python",
       "seeAlso": [
@@ -2398,7 +2398,7 @@
       "reference": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": 188,
+      "referenceNumber": 647,
       "name": "CNRI Python Open Source GPL Compatible License Agreement",
       "licenseId": "CNRI-Python-GPL-Compatible",
       "seeAlso": [
@@ -2410,7 +2410,7 @@
       "reference": "https://spdx.org/licenses/COIL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/COIL-1.0.json",
-      "referenceNumber": 570,
+      "referenceNumber": 196,
       "name": "Copyfree Open Innovation License",
       "licenseId": "COIL-1.0",
       "seeAlso": [
@@ -2422,7 +2422,7 @@
       "reference": "https://spdx.org/licenses/Community-Spec-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Community-Spec-1.0.json",
-      "referenceNumber": 332,
+      "referenceNumber": 29,
       "name": "Community Specification License 1.0",
       "licenseId": "Community-Spec-1.0",
       "seeAlso": [
@@ -2434,7 +2434,7 @@
       "reference": "https://spdx.org/licenses/Condor-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": 201,
+      "referenceNumber": 276,
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -2448,7 +2448,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.0.json",
-      "referenceNumber": 28,
+      "referenceNumber": 317,
       "name": "copyleft-next 0.3.0",
       "licenseId": "copyleft-next-0.3.0",
       "seeAlso": [
@@ -2460,7 +2460,7 @@
       "reference": "https://spdx.org/licenses/copyleft-next-0.3.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/copyleft-next-0.3.1.json",
-      "referenceNumber": 19,
+      "referenceNumber": 300,
       "name": "copyleft-next 0.3.1",
       "licenseId": "copyleft-next-0.3.1",
       "seeAlso": [
@@ -2472,7 +2472,7 @@
       "reference": "https://spdx.org/licenses/Cornell-Lossless-JPEG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cornell-Lossless-JPEG.json",
-      "referenceNumber": 481,
+      "referenceNumber": 173,
       "name": "Cornell Lossless JPEG License",
       "licenseId": "Cornell-Lossless-JPEG",
       "seeAlso": [
@@ -2486,7 +2486,7 @@
       "reference": "https://spdx.org/licenses/CPAL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": 218,
+      "referenceNumber": 327,
       "name": "Common Public Attribution License 1.0",
       "licenseId": "CPAL-1.0",
       "seeAlso": [
@@ -2499,7 +2499,7 @@
       "reference": "https://spdx.org/licenses/CPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": 322,
+      "referenceNumber": 39,
       "name": "Common Public License 1.0",
       "licenseId": "CPL-1.0",
       "seeAlso": [
@@ -2512,7 +2512,7 @@
       "reference": "https://spdx.org/licenses/CPOL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": 23,
+      "referenceNumber": 419,
       "name": "Code Project Open License 1.02",
       "licenseId": "CPOL-1.02",
       "seeAlso": [
@@ -2525,7 +2525,7 @@
       "reference": "https://spdx.org/licenses/Cronyx.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cronyx.json",
-      "referenceNumber": 301,
+      "referenceNumber": 328,
       "name": "Cronyx License",
       "licenseId": "Cronyx",
       "seeAlso": [
@@ -2540,7 +2540,7 @@
       "reference": "https://spdx.org/licenses/Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Crossword.json",
-      "referenceNumber": 280,
+      "referenceNumber": 303,
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -2552,7 +2552,7 @@
       "reference": "https://spdx.org/licenses/CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": 75,
+      "referenceNumber": 31,
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -2564,7 +2564,7 @@
       "reference": "https://spdx.org/licenses/CUA-OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": 159,
+      "referenceNumber": 151,
       "name": "CUA Office Public License v1.0",
       "licenseId": "CUA-OPL-1.0",
       "seeAlso": [
@@ -2576,7 +2576,7 @@
       "reference": "https://spdx.org/licenses/Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Cube.json",
-      "referenceNumber": 525,
+      "referenceNumber": 104,
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -2588,7 +2588,7 @@
       "reference": "https://spdx.org/licenses/curl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/curl.json",
-      "referenceNumber": 74,
+      "referenceNumber": 575,
       "name": "curl License",
       "licenseId": "curl",
       "seeAlso": [
@@ -2600,7 +2600,7 @@
       "reference": "https://spdx.org/licenses/cve-tou.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/cve-tou.json",
-      "referenceNumber": 526,
+      "referenceNumber": 15,
       "name": "Common Vulnerability Enumeration ToU License",
       "licenseId": "cve-tou",
       "seeAlso": [
@@ -2612,7 +2612,7 @@
       "reference": "https://spdx.org/licenses/D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": 458,
+      "referenceNumber": 265,
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -2631,7 +2631,7 @@
       "reference": "https://spdx.org/licenses/DEC-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DEC-3-Clause.json",
-      "referenceNumber": 157,
+      "referenceNumber": 458,
       "name": "DEC 3-Clause License",
       "licenseId": "DEC-3-Clause",
       "seeAlso": [
@@ -2643,7 +2643,7 @@
       "reference": "https://spdx.org/licenses/diffmark.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/diffmark.json",
-      "referenceNumber": 636,
+      "referenceNumber": 277,
       "name": "diffmark license",
       "licenseId": "diffmark",
       "seeAlso": [
@@ -2655,7 +2655,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-BY-2.0.json",
-      "referenceNumber": 659,
+      "referenceNumber": 142,
       "name": "Data licence Germany – attribution – version 2.0",
       "licenseId": "DL-DE-BY-2.0",
       "seeAlso": [
@@ -2667,7 +2667,7 @@
       "reference": "https://spdx.org/licenses/DL-DE-ZERO-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DL-DE-ZERO-2.0.json",
-      "referenceNumber": 41,
+      "referenceNumber": 473,
       "name": "Data licence Germany – zero – version 2.0",
       "licenseId": "DL-DE-ZERO-2.0",
       "seeAlso": [
@@ -2679,7 +2679,7 @@
       "reference": "https://spdx.org/licenses/DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DOC.json",
-      "referenceNumber": 381,
+      "referenceNumber": 176,
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
@@ -2692,7 +2692,7 @@
       "reference": "https://spdx.org/licenses/DocBook-Schema.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-Schema.json",
-      "referenceNumber": 537,
+      "referenceNumber": 305,
       "name": "DocBook Schema License",
       "licenseId": "DocBook-Schema",
       "seeAlso": [
@@ -2704,7 +2704,7 @@
       "reference": "https://spdx.org/licenses/DocBook-Stylesheet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-Stylesheet.json",
-      "referenceNumber": 579,
+      "referenceNumber": 250,
       "name": "DocBook Stylesheet License",
       "licenseId": "DocBook-Stylesheet",
       "seeAlso": [
@@ -2716,7 +2716,7 @@
       "reference": "https://spdx.org/licenses/DocBook-XML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DocBook-XML.json",
-      "referenceNumber": 320,
+      "referenceNumber": 220,
       "name": "DocBook XML License",
       "licenseId": "DocBook-XML",
       "seeAlso": [
@@ -2728,7 +2728,7 @@
       "reference": "https://spdx.org/licenses/Dotseqn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": 140,
+      "referenceNumber": 462,
       "name": "Dotseqn License",
       "licenseId": "Dotseqn",
       "seeAlso": [
@@ -2740,7 +2740,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.0.json",
-      "referenceNumber": 611,
+      "referenceNumber": 331,
       "name": "Detection Rule License 1.0",
       "licenseId": "DRL-1.0",
       "seeAlso": [
@@ -2752,7 +2752,7 @@
       "reference": "https://spdx.org/licenses/DRL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DRL-1.1.json",
-      "referenceNumber": 572,
+      "referenceNumber": 632,
       "name": "Detection Rule License 1.1",
       "licenseId": "DRL-1.1",
       "seeAlso": [
@@ -2764,7 +2764,7 @@
       "reference": "https://spdx.org/licenses/DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/DSDP.json",
-      "referenceNumber": 544,
+      "referenceNumber": 0,
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -2776,7 +2776,7 @@
       "reference": "https://spdx.org/licenses/dtoa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dtoa.json",
-      "referenceNumber": 658,
+      "referenceNumber": 124,
       "name": "David M. Gay dtoa License",
       "licenseId": "dtoa",
       "seeAlso": [
@@ -2789,7 +2789,7 @@
       "reference": "https://spdx.org/licenses/dvipdfm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": 390,
+      "referenceNumber": 301,
       "name": "dvipdfm License",
       "licenseId": "dvipdfm",
       "seeAlso": [
@@ -2801,7 +2801,7 @@
       "reference": "https://spdx.org/licenses/ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": 533,
+      "referenceNumber": 38,
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
@@ -2813,7 +2813,7 @@
       "reference": "https://spdx.org/licenses/ECL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": 445,
+      "referenceNumber": 174,
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
@@ -2826,7 +2826,7 @@
       "reference": "https://spdx.org/licenses/eCos-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": 439,
+      "referenceNumber": 17,
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
@@ -2839,7 +2839,7 @@
       "reference": "https://spdx.org/licenses/EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": 400,
+      "referenceNumber": 202,
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
@@ -2852,7 +2852,7 @@
       "reference": "https://spdx.org/licenses/EFL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": 450,
+      "referenceNumber": 525,
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
@@ -2866,7 +2866,7 @@
       "reference": "https://spdx.org/licenses/eGenix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/eGenix.json",
-      "referenceNumber": 394,
+      "referenceNumber": 128,
       "name": "eGenix.com Public License 1.1.0",
       "licenseId": "eGenix",
       "seeAlso": [
@@ -2879,7 +2879,7 @@
       "reference": "https://spdx.org/licenses/Elastic-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Elastic-2.0.json",
-      "referenceNumber": 512,
+      "referenceNumber": 40,
       "name": "Elastic License 2.0",
       "licenseId": "Elastic-2.0",
       "seeAlso": [
@@ -2892,7 +2892,7 @@
       "reference": "https://spdx.org/licenses/Entessa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Entessa.json",
-      "referenceNumber": 660,
+      "referenceNumber": 203,
       "name": "Entessa Public License v1.0",
       "licenseId": "Entessa",
       "seeAlso": [
@@ -2904,7 +2904,7 @@
       "reference": "https://spdx.org/licenses/EPICS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPICS.json",
-      "referenceNumber": 650,
+      "referenceNumber": 167,
       "name": "EPICS Open License",
       "licenseId": "EPICS",
       "seeAlso": [
@@ -2916,7 +2916,7 @@
       "reference": "https://spdx.org/licenses/EPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": 640,
+      "referenceNumber": 90,
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
@@ -2930,7 +2930,7 @@
       "reference": "https://spdx.org/licenses/EPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": 467,
+      "referenceNumber": 378,
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -2944,7 +2944,7 @@
       "reference": "https://spdx.org/licenses/ErlPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": 275,
+      "referenceNumber": 572,
       "name": "Erlang Public License v1.1",
       "licenseId": "ErlPL-1.1",
       "seeAlso": [
@@ -2956,7 +2956,7 @@
       "reference": "https://spdx.org/licenses/etalab-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/etalab-2.0.json",
-      "referenceNumber": 273,
+      "referenceNumber": 596,
       "name": "Etalab Open License 2.0",
       "licenseId": "etalab-2.0",
       "seeAlso": [
@@ -2969,7 +2969,7 @@
       "reference": "https://spdx.org/licenses/EUDatagrid.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": 66,
+      "referenceNumber": 118,
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
@@ -2983,7 +2983,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": 639,
+      "referenceNumber": 175,
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -2996,7 +2996,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": 163,
+      "referenceNumber": 470,
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
@@ -3011,7 +3011,7 @@
       "reference": "https://spdx.org/licenses/EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": 596,
+      "referenceNumber": 403,
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
@@ -3029,7 +3029,7 @@
       "reference": "https://spdx.org/licenses/Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": 15,
+      "referenceNumber": 323,
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -3041,7 +3041,7 @@
       "reference": "https://spdx.org/licenses/Fair.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Fair.json",
-      "referenceNumber": 39,
+      "referenceNumber": 245,
       "name": "Fair License",
       "licenseId": "Fair",
       "seeAlso": [
@@ -3054,7 +3054,7 @@
       "reference": "https://spdx.org/licenses/FBM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FBM.json",
-      "referenceNumber": 235,
+      "referenceNumber": 234,
       "name": "Fuzzy Bitmap License",
       "licenseId": "FBM",
       "seeAlso": [
@@ -3066,7 +3066,7 @@
       "reference": "https://spdx.org/licenses/FDK-AAC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FDK-AAC.json",
-      "referenceNumber": 628,
+      "referenceNumber": 304,
       "name": "Fraunhofer FDK AAC Codec Library",
       "licenseId": "FDK-AAC",
       "seeAlso": [
@@ -3079,7 +3079,7 @@
       "reference": "https://spdx.org/licenses/Ferguson-Twofish.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ferguson-Twofish.json",
-      "referenceNumber": 98,
+      "referenceNumber": 338,
       "name": "Ferguson Twofish License",
       "licenseId": "Ferguson-Twofish",
       "seeAlso": [
@@ -3091,7 +3091,7 @@
       "reference": "https://spdx.org/licenses/Frameworx-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": 286,
+      "referenceNumber": 252,
       "name": "Frameworx Open License 1.0",
       "licenseId": "Frameworx-1.0",
       "seeAlso": [
@@ -3103,7 +3103,7 @@
       "reference": "https://spdx.org/licenses/FreeBSD-DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeBSD-DOC.json",
-      "referenceNumber": 504,
+      "referenceNumber": 550,
       "name": "FreeBSD Documentation License",
       "licenseId": "FreeBSD-DOC",
       "seeAlso": [
@@ -3115,7 +3115,7 @@
       "reference": "https://spdx.org/licenses/FreeImage.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": 643,
+      "referenceNumber": 261,
       "name": "FreeImage Public License v1.0",
       "licenseId": "FreeImage",
       "seeAlso": [
@@ -3127,7 +3127,7 @@
       "reference": "https://spdx.org/licenses/FSFAP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": 126,
+      "referenceNumber": 113,
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
@@ -3140,7 +3140,7 @@
       "reference": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFAP-no-warranty-disclaimer.json",
-      "referenceNumber": 415,
+      "referenceNumber": 579,
       "name": "FSF All Permissive License (without Warranty)",
       "licenseId": "FSFAP-no-warranty-disclaimer",
       "seeAlso": [
@@ -3152,7 +3152,7 @@
       "reference": "https://spdx.org/licenses/FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": 4,
+      "referenceNumber": 578,
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -3164,7 +3164,7 @@
       "reference": "https://spdx.org/licenses/FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": 421,
+      "referenceNumber": 52,
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -3176,7 +3176,7 @@
       "reference": "https://spdx.org/licenses/FSFULLRWD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FSFULLRWD.json",
-      "referenceNumber": 141,
+      "referenceNumber": 209,
       "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
       "licenseId": "FSFULLRWD",
       "seeAlso": [
@@ -3188,7 +3188,7 @@
       "reference": "https://spdx.org/licenses/FTL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/FTL.json",
-      "referenceNumber": 237,
+      "referenceNumber": 309,
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -3203,7 +3203,7 @@
       "reference": "https://spdx.org/licenses/Furuseth.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Furuseth.json",
-      "referenceNumber": 220,
+      "referenceNumber": 564,
       "name": "Furuseth License",
       "licenseId": "Furuseth",
       "seeAlso": [
@@ -3215,7 +3215,7 @@
       "reference": "https://spdx.org/licenses/fwlw.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/fwlw.json",
-      "referenceNumber": 426,
+      "referenceNumber": 80,
       "name": "fwlw License",
       "licenseId": "fwlw",
       "seeAlso": [
@@ -3227,7 +3227,7 @@
       "reference": "https://spdx.org/licenses/GCR-docs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GCR-docs.json",
-      "referenceNumber": 335,
+      "referenceNumber": 137,
       "name": "Gnome GCR Documentation License",
       "licenseId": "GCR-docs",
       "seeAlso": [
@@ -3239,7 +3239,7 @@
       "reference": "https://spdx.org/licenses/GD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GD.json",
-      "referenceNumber": 266,
+      "referenceNumber": 333,
       "name": "GD License",
       "licenseId": "GD",
       "seeAlso": [
@@ -3251,7 +3251,7 @@
       "reference": "https://spdx.org/licenses/generic-xts.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/generic-xts.json",
-      "referenceNumber": 314,
+      "referenceNumber": 482,
       "name": "Generic XTS License",
       "licenseId": "generic-xts",
       "seeAlso": [
@@ -3263,7 +3263,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": 574,
+      "referenceNumber": 273,
       "name": "GNU Free Documentation License v1.1",
       "licenseId": "GFDL-1.1",
       "seeAlso": [
@@ -3276,7 +3276,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-only.json",
-      "referenceNumber": 134,
+      "referenceNumber": 452,
       "name": "GNU Free Documentation License v1.1 only - invariants",
       "licenseId": "GFDL-1.1-invariants-only",
       "seeAlso": [
@@ -3288,7 +3288,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
-      "referenceNumber": 359,
+      "referenceNumber": 152,
       "name": "GNU Free Documentation License v1.1 or later - invariants",
       "licenseId": "GFDL-1.1-invariants-or-later",
       "seeAlso": [
@@ -3300,7 +3300,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
-      "referenceNumber": 154,
+      "referenceNumber": 237,
       "name": "GNU Free Documentation License v1.1 only - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-only",
       "seeAlso": [
@@ -3312,7 +3312,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
-      "referenceNumber": 408,
+      "referenceNumber": 626,
       "name": "GNU Free Documentation License v1.1 or later - no invariants",
       "licenseId": "GFDL-1.1-no-invariants-or-later",
       "seeAlso": [
@@ -3324,7 +3324,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": 490,
+      "referenceNumber": 613,
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
@@ -3337,7 +3337,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": 557,
+      "referenceNumber": 161,
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
@@ -3350,7 +3350,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": 653,
+      "referenceNumber": 642,
       "name": "GNU Free Documentation License v1.2",
       "licenseId": "GFDL-1.2",
       "seeAlso": [
@@ -3363,7 +3363,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-only.json",
-      "referenceNumber": 7,
+      "referenceNumber": 200,
       "name": "GNU Free Documentation License v1.2 only - invariants",
       "licenseId": "GFDL-1.2-invariants-only",
       "seeAlso": [
@@ -3375,7 +3375,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
-      "referenceNumber": 429,
+      "referenceNumber": 358,
       "name": "GNU Free Documentation License v1.2 or later - invariants",
       "licenseId": "GFDL-1.2-invariants-or-later",
       "seeAlso": [
@@ -3387,7 +3387,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
-      "referenceNumber": 283,
+      "referenceNumber": 45,
       "name": "GNU Free Documentation License v1.2 only - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-only",
       "seeAlso": [
@@ -3399,7 +3399,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
-      "referenceNumber": 386,
+      "referenceNumber": 330,
       "name": "GNU Free Documentation License v1.2 or later - no invariants",
       "licenseId": "GFDL-1.2-no-invariants-or-later",
       "seeAlso": [
@@ -3411,7 +3411,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": 111,
+      "referenceNumber": 661,
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
@@ -3424,7 +3424,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.2-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": 360,
+      "referenceNumber": 436,
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
@@ -3437,7 +3437,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": 100,
+      "referenceNumber": 379,
       "name": "GNU Free Documentation License v1.3",
       "licenseId": "GFDL-1.3",
       "seeAlso": [
@@ -3450,7 +3450,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-only.json",
-      "referenceNumber": 298,
+      "referenceNumber": 567,
       "name": "GNU Free Documentation License v1.3 only - invariants",
       "licenseId": "GFDL-1.3-invariants-only",
       "seeAlso": [
@@ -3462,7 +3462,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
-      "referenceNumber": 166,
+      "referenceNumber": 504,
       "name": "GNU Free Documentation License v1.3 or later - invariants",
       "licenseId": "GFDL-1.3-invariants-or-later",
       "seeAlso": [
@@ -3474,7 +3474,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
-      "referenceNumber": 292,
+      "referenceNumber": 66,
       "name": "GNU Free Documentation License v1.3 only - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-only",
       "seeAlso": [
@@ -3486,7 +3486,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
-      "referenceNumber": 478,
+      "referenceNumber": 677,
       "name": "GNU Free Documentation License v1.3 or later - no invariants",
       "licenseId": "GFDL-1.3-no-invariants-or-later",
       "seeAlso": [
@@ -3498,7 +3498,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": 575,
+      "referenceNumber": 311,
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
@@ -3511,7 +3511,7 @@
       "reference": "https://spdx.org/licenses/GFDL-1.3-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": 177,
+      "referenceNumber": 141,
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
@@ -3524,7 +3524,7 @@
       "reference": "https://spdx.org/licenses/Giftware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Giftware.json",
-      "referenceNumber": 183,
+      "referenceNumber": 657,
       "name": "Giftware License",
       "licenseId": "Giftware",
       "seeAlso": [
@@ -3536,7 +3536,7 @@
       "reference": "https://spdx.org/licenses/GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": 491,
+      "referenceNumber": 638,
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -3548,7 +3548,7 @@
       "reference": "https://spdx.org/licenses/Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glide.json",
-      "referenceNumber": 337,
+      "referenceNumber": 199,
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -3560,7 +3560,7 @@
       "reference": "https://spdx.org/licenses/Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": 554,
+      "referenceNumber": 483,
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -3572,7 +3572,7 @@
       "reference": "https://spdx.org/licenses/GLWTPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GLWTPL.json",
-      "referenceNumber": 483,
+      "referenceNumber": 7,
       "name": "Good Luck With That Public License",
       "licenseId": "GLWTPL",
       "seeAlso": [
@@ -3584,7 +3584,7 @@
       "reference": "https://spdx.org/licenses/gnuplot.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": 511,
+      "referenceNumber": 216,
       "name": "gnuplot License",
       "licenseId": "gnuplot",
       "seeAlso": [
@@ -3597,7 +3597,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": 517,
+      "referenceNumber": 266,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0",
       "seeAlso": [
@@ -3609,7 +3609,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": 552,
+      "referenceNumber": 297,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0+",
       "seeAlso": [
@@ -3621,7 +3621,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": 174,
+      "referenceNumber": 354,
       "name": "GNU General Public License v1.0 only",
       "licenseId": "GPL-1.0-only",
       "seeAlso": [
@@ -3633,7 +3633,7 @@
       "reference": "https://spdx.org/licenses/GPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": 18,
+      "referenceNumber": 377,
       "name": "GNU General Public License v1.0 or later",
       "licenseId": "GPL-1.0-or-later",
       "seeAlso": [
@@ -3645,7 +3645,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": 47,
+      "referenceNumber": 188,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0",
       "seeAlso": [
@@ -3659,7 +3659,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": 626,
+      "referenceNumber": 643,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0+",
       "seeAlso": [
@@ -3673,7 +3673,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": 612,
+      "referenceNumber": 171,
       "name": "GNU General Public License v2.0 only",
       "licenseId": "GPL-2.0-only",
       "seeAlso": [
@@ -3688,7 +3688,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": 454,
+      "referenceNumber": 424,
       "name": "GNU General Public License v2.0 or later",
       "licenseId": "GPL-2.0-or-later",
       "seeAlso": [
@@ -3702,7 +3702,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": 402,
+      "referenceNumber": 629,
       "name": "GNU General Public License v2.0 w/Autoconf exception",
       "licenseId": "GPL-2.0-with-autoconf-exception",
       "seeAlso": [
@@ -3714,7 +3714,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": 536,
+      "referenceNumber": 35,
       "name": "GNU General Public License v2.0 w/Bison exception",
       "licenseId": "GPL-2.0-with-bison-exception",
       "seeAlso": [
@@ -3726,7 +3726,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": 326,
+      "referenceNumber": 409,
       "name": "GNU General Public License v2.0 w/Classpath exception",
       "licenseId": "GPL-2.0-with-classpath-exception",
       "seeAlso": [
@@ -3738,7 +3738,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-font-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": 666,
+      "referenceNumber": 548,
       "name": "GNU General Public License v2.0 w/Font exception",
       "licenseId": "GPL-2.0-with-font-exception",
       "seeAlso": [
@@ -3750,7 +3750,7 @@
       "reference": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": 321,
+      "referenceNumber": 464,
       "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-2.0-with-GCC-exception",
       "seeAlso": [
@@ -3762,7 +3762,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": 169,
+      "referenceNumber": 645,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0",
       "seeAlso": [
@@ -3776,7 +3776,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": 564,
+      "referenceNumber": 501,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0+",
       "seeAlso": [
@@ -3790,7 +3790,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": 436,
+      "referenceNumber": 585,
       "name": "GNU General Public License v3.0 only",
       "licenseId": "GPL-3.0-only",
       "seeAlso": [
@@ -3804,7 +3804,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": 614,
+      "referenceNumber": 448,
       "name": "GNU General Public License v3.0 or later",
       "licenseId": "GPL-3.0-or-later",
       "seeAlso": [
@@ -3818,7 +3818,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": 549,
+      "referenceNumber": 659,
       "name": "GNU General Public License v3.0 w/Autoconf exception",
       "licenseId": "GPL-3.0-with-autoconf-exception",
       "seeAlso": [
@@ -3830,7 +3830,7 @@
       "reference": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": 208,
+      "referenceNumber": 163,
       "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
       "licenseId": "GPL-3.0-with-GCC-exception",
       "seeAlso": [
@@ -3842,7 +3842,7 @@
       "reference": "https://spdx.org/licenses/Graphics-Gems.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Graphics-Gems.json",
-      "referenceNumber": 281,
+      "referenceNumber": 55,
       "name": "Graphics Gems License",
       "licenseId": "Graphics-Gems",
       "seeAlso": [
@@ -3854,7 +3854,7 @@
       "reference": "https://spdx.org/licenses/gSOAP-1.3b.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": 25,
+      "referenceNumber": 315,
       "name": "gSOAP Public License v1.3b",
       "licenseId": "gSOAP-1.3b",
       "seeAlso": [
@@ -3866,7 +3866,7 @@
       "reference": "https://spdx.org/licenses/gtkbook.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/gtkbook.json",
-      "referenceNumber": 3,
+      "referenceNumber": 361,
       "name": "gtkbook License",
       "licenseId": "gtkbook",
       "seeAlso": [
@@ -3879,7 +3879,7 @@
       "reference": "https://spdx.org/licenses/Gutmann.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Gutmann.json",
-      "referenceNumber": 496,
+      "referenceNumber": 30,
       "name": "Gutmann License",
       "licenseId": "Gutmann",
       "seeAlso": [
@@ -3891,7 +3891,7 @@
       "reference": "https://spdx.org/licenses/HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": 534,
+      "referenceNumber": 591,
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -3903,7 +3903,7 @@
       "reference": "https://spdx.org/licenses/hdparm.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/hdparm.json",
-      "referenceNumber": 87,
+      "referenceNumber": 139,
       "name": "hdparm License",
       "licenseId": "hdparm",
       "seeAlso": [
@@ -3915,7 +3915,7 @@
       "reference": "https://spdx.org/licenses/HIDAPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HIDAPI.json",
-      "referenceNumber": 471,
+      "referenceNumber": 637,
       "name": "HIDAPI License",
       "licenseId": "HIDAPI",
       "seeAlso": [
@@ -3927,7 +3927,7 @@
       "reference": "https://spdx.org/licenses/Hippocratic-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Hippocratic-2.1.json",
-      "referenceNumber": 566,
+      "referenceNumber": 280,
       "name": "Hippocratic License 2.1",
       "licenseId": "Hippocratic-2.1",
       "seeAlso": [
@@ -3940,7 +3940,7 @@
       "reference": "https://spdx.org/licenses/HP-1986.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1986.json",
-      "referenceNumber": 182,
+      "referenceNumber": 156,
       "name": "Hewlett-Packard 1986 License",
       "licenseId": "HP-1986",
       "seeAlso": [
@@ -3952,7 +3952,7 @@
       "reference": "https://spdx.org/licenses/HP-1989.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HP-1989.json",
-      "referenceNumber": 202,
+      "referenceNumber": 210,
       "name": "Hewlett-Packard 1989 License",
       "licenseId": "HP-1989",
       "seeAlso": [
@@ -3964,7 +3964,7 @@
       "reference": "https://spdx.org/licenses/HPND.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND.json",
-      "referenceNumber": 40,
+      "referenceNumber": 381,
       "name": "Historical Permission Notice and Disclaimer",
       "licenseId": "HPND",
       "seeAlso": [
@@ -3978,7 +3978,7 @@
       "reference": "https://spdx.org/licenses/HPND-DEC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-DEC.json",
-      "referenceNumber": 474,
+      "referenceNumber": 449,
       "name": "Historical Permission Notice and Disclaimer - DEC variant",
       "licenseId": "HPND-DEC",
       "seeAlso": [
@@ -3990,7 +3990,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc.json",
-      "referenceNumber": 625,
+      "referenceNumber": 238,
       "name": "Historical Permission Notice and Disclaimer - documentation variant",
       "licenseId": "HPND-doc",
       "seeAlso": [
@@ -4003,7 +4003,7 @@
       "reference": "https://spdx.org/licenses/HPND-doc-sell.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-doc-sell.json",
-      "referenceNumber": 257,
+      "referenceNumber": 675,
       "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
       "licenseId": "HPND-doc-sell",
       "seeAlso": [
@@ -4016,7 +4016,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US.json",
-      "referenceNumber": 144,
+      "referenceNumber": 154,
       "name": "HPND with US Government export control warning",
       "licenseId": "HPND-export-US",
       "seeAlso": [
@@ -4028,7 +4028,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-acknowledgement.json",
-      "referenceNumber": 540,
+      "referenceNumber": 56,
       "name": "HPND with US Government export control warning and acknowledgment",
       "licenseId": "HPND-export-US-acknowledgement",
       "seeAlso": [
@@ -4041,7 +4041,7 @@
       "reference": "https://spdx.org/licenses/HPND-export-US-modify.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export-US-modify.json",
-      "referenceNumber": 563,
+      "referenceNumber": 476,
       "name": "HPND with US Government export control warning and modification rqmt",
       "licenseId": "HPND-export-US-modify",
       "seeAlso": [
@@ -4054,7 +4054,7 @@
       "reference": "https://spdx.org/licenses/HPND-export2-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-export2-US.json",
-      "referenceNumber": 61,
+      "referenceNumber": 678,
       "name": "HPND with US Government export control and 2 disclaimers",
       "licenseId": "HPND-export2-US",
       "seeAlso": [
@@ -4067,7 +4067,7 @@
       "reference": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Fenneberg-Livingston.json",
-      "referenceNumber": 446,
+      "referenceNumber": 407,
       "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
       "licenseId": "HPND-Fenneberg-Livingston",
       "seeAlso": [
@@ -4080,7 +4080,7 @@
       "reference": "https://spdx.org/licenses/HPND-INRIA-IMAG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-INRIA-IMAG.json",
-      "referenceNumber": 297,
+      "referenceNumber": 611,
       "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
       "licenseId": "HPND-INRIA-IMAG",
       "seeAlso": [
@@ -4092,7 +4092,7 @@
       "reference": "https://spdx.org/licenses/HPND-Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Intel.json",
-      "referenceNumber": 240,
+      "referenceNumber": 93,
       "name": "Historical Permission Notice and Disclaimer - Intel variant",
       "licenseId": "HPND-Intel",
       "seeAlso": [
@@ -4104,7 +4104,7 @@
       "reference": "https://spdx.org/licenses/HPND-Kevlin-Henney.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Kevlin-Henney.json",
-      "referenceNumber": 131,
+      "referenceNumber": 271,
       "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
       "licenseId": "HPND-Kevlin-Henney",
       "seeAlso": [
@@ -4116,7 +4116,7 @@
       "reference": "https://spdx.org/licenses/HPND-Markus-Kuhn.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Markus-Kuhn.json",
-      "referenceNumber": 528,
+      "referenceNumber": 454,
       "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
       "licenseId": "HPND-Markus-Kuhn",
       "seeAlso": [
@@ -4129,7 +4129,7 @@
       "reference": "https://spdx.org/licenses/HPND-merchantability-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-merchantability-variant.json",
-      "referenceNumber": 410,
+      "referenceNumber": 215,
       "name": "Historical Permission Notice and Disclaimer - merchantability variant",
       "licenseId": "HPND-merchantability-variant",
       "seeAlso": [
@@ -4141,7 +4141,7 @@
       "reference": "https://spdx.org/licenses/HPND-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-MIT-disclaimer.json",
-      "referenceNumber": 232,
+      "referenceNumber": 451,
       "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
       "licenseId": "HPND-MIT-disclaimer",
       "seeAlso": [
@@ -4153,7 +4153,7 @@
       "reference": "https://spdx.org/licenses/HPND-Netrek.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Netrek.json",
-      "referenceNumber": 291,
+      "referenceNumber": 608,
       "name": "Historical Permission Notice and Disclaimer - Netrek variant",
       "licenseId": "HPND-Netrek",
       "seeAlso": [],
@@ -4163,7 +4163,7 @@
       "reference": "https://spdx.org/licenses/HPND-Pbmplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-Pbmplus.json",
-      "referenceNumber": 142,
+      "referenceNumber": 590,
       "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
       "licenseId": "HPND-Pbmplus",
       "seeAlso": [
@@ -4175,7 +4175,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-MIT-disclaimer-xserver.json",
-      "referenceNumber": 461,
+      "referenceNumber": 658,
       "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
       "licenseId": "HPND-sell-MIT-disclaimer-xserver",
       "seeAlso": [
@@ -4187,7 +4187,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-regexpr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-regexpr.json",
-      "referenceNumber": 561,
+      "referenceNumber": 527,
       "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
       "licenseId": "HPND-sell-regexpr",
       "seeAlso": [
@@ -4199,11 +4199,12 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant.json",
-      "referenceNumber": 88,
+      "referenceNumber": 226,
       "name": "Historical Permission Notice and Disclaimer - sell variant",
       "licenseId": "HPND-sell-variant",
       "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19"
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h\u003dv4.19",
+        "https://github.com/kfish/xsel/blob/master/COPYING"
       ],
       "isOsiApproved": false
     },
@@ -4211,7 +4212,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer.json",
-      "referenceNumber": 343,
+      "referenceNumber": 57,
       "name": "HPND sell variant with MIT disclaimer",
       "licenseId": "HPND-sell-variant-MIT-disclaimer",
       "seeAlso": [
@@ -4223,7 +4224,7 @@
       "reference": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-sell-variant-MIT-disclaimer-rev.json",
-      "referenceNumber": 387,
+      "referenceNumber": 662,
       "name": "HPND sell variant with MIT disclaimer - reverse",
       "licenseId": "HPND-sell-variant-MIT-disclaimer-rev",
       "seeAlso": [
@@ -4235,7 +4236,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC.json",
-      "referenceNumber": 269,
+      "referenceNumber": 466,
       "name": "Historical Permission Notice and Disclaimer - University of California variant",
       "licenseId": "HPND-UC",
       "seeAlso": [
@@ -4247,7 +4248,7 @@
       "reference": "https://spdx.org/licenses/HPND-UC-export-US.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HPND-UC-export-US.json",
-      "referenceNumber": 130,
+      "referenceNumber": 92,
       "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
       "licenseId": "HPND-UC-export-US",
       "seeAlso": [
@@ -4259,7 +4260,7 @@
       "reference": "https://spdx.org/licenses/HTMLTIDY.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/HTMLTIDY.json",
-      "referenceNumber": 590,
+      "referenceNumber": 95,
       "name": "HTML Tidy License",
       "licenseId": "HTMLTIDY",
       "seeAlso": [
@@ -4271,7 +4272,7 @@
       "reference": "https://spdx.org/licenses/IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": 150,
+      "referenceNumber": 674,
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -4283,7 +4284,7 @@
       "reference": "https://spdx.org/licenses/ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ICU.json",
-      "referenceNumber": 523,
+      "referenceNumber": 520,
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -4295,7 +4296,7 @@
       "reference": "https://spdx.org/licenses/IEC-Code-Components-EULA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IEC-Code-Components-EULA.json",
-      "referenceNumber": 72,
+      "referenceNumber": 214,
       "name": "IEC    Code Components End-user licence agreement",
       "licenseId": "IEC-Code-Components-EULA",
       "seeAlso": [
@@ -4309,7 +4310,7 @@
       "reference": "https://spdx.org/licenses/IJG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG.json",
-      "referenceNumber": 409,
+      "referenceNumber": 344,
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -4322,7 +4323,7 @@
       "reference": "https://spdx.org/licenses/IJG-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IJG-short.json",
-      "referenceNumber": 466,
+      "referenceNumber": 492,
       "name": "Independent JPEG Group License - short",
       "licenseId": "IJG-short",
       "seeAlso": [
@@ -4334,7 +4335,7 @@
       "reference": "https://spdx.org/licenses/ImageMagick.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": 616,
+      "referenceNumber": 584,
       "name": "ImageMagick License",
       "licenseId": "ImageMagick",
       "seeAlso": [
@@ -4346,7 +4347,7 @@
       "reference": "https://spdx.org/licenses/iMatix.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/iMatix.json",
-      "referenceNumber": 434,
+      "referenceNumber": 129,
       "name": "iMatix Standard Function Library Agreement",
       "licenseId": "iMatix",
       "seeAlso": [
@@ -4359,7 +4360,7 @@
       "reference": "https://spdx.org/licenses/Imlib2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": 145,
+      "referenceNumber": 365,
       "name": "Imlib2 License",
       "licenseId": "Imlib2",
       "seeAlso": [
@@ -4373,7 +4374,7 @@
       "reference": "https://spdx.org/licenses/Info-ZIP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": 654,
+      "referenceNumber": 9,
       "name": "Info-ZIP License",
       "licenseId": "Info-ZIP",
       "seeAlso": [
@@ -4385,7 +4386,7 @@
       "reference": "https://spdx.org/licenses/Inner-Net-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Inner-Net-2.0.json",
-      "referenceNumber": 206,
+      "referenceNumber": 350,
       "name": "Inner Net License v2.0",
       "licenseId": "Inner-Net-2.0",
       "seeAlso": [
@@ -4398,7 +4399,7 @@
       "reference": "https://spdx.org/licenses/InnoSetup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/InnoSetup.json",
-      "referenceNumber": 196,
+      "referenceNumber": 28,
       "name": "Inno Setup License",
       "licenseId": "InnoSetup",
       "seeAlso": [
@@ -4410,7 +4411,7 @@
       "reference": "https://spdx.org/licenses/Intel.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel.json",
-      "referenceNumber": 313,
+      "referenceNumber": 465,
       "name": "Intel Open Source License",
       "licenseId": "Intel",
       "seeAlso": [
@@ -4423,7 +4424,7 @@
       "reference": "https://spdx.org/licenses/Intel-ACPI.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": 339,
+      "referenceNumber": 509,
       "name": "Intel ACPI Software License Agreement",
       "licenseId": "Intel-ACPI",
       "seeAlso": [
@@ -4435,7 +4436,7 @@
       "reference": "https://spdx.org/licenses/Interbase-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": 618,
+      "referenceNumber": 606,
       "name": "Interbase Public License v1.0",
       "licenseId": "Interbase-1.0",
       "seeAlso": [
@@ -4447,7 +4448,7 @@
       "reference": "https://spdx.org/licenses/IPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPA.json",
-      "referenceNumber": 369,
+      "referenceNumber": 16,
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
@@ -4460,7 +4461,7 @@
       "reference": "https://spdx.org/licenses/IPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": 502,
+      "referenceNumber": 19,
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
@@ -4473,7 +4474,7 @@
       "reference": "https://spdx.org/licenses/ISC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC.json",
-      "referenceNumber": 437,
+      "referenceNumber": 598,
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
@@ -4488,7 +4489,7 @@
       "reference": "https://spdx.org/licenses/ISC-Veillard.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ISC-Veillard.json",
-      "referenceNumber": 524,
+      "referenceNumber": 401,
       "name": "ISC Veillard variant",
       "licenseId": "ISC-Veillard",
       "seeAlso": [
@@ -4502,7 +4503,7 @@
       "reference": "https://spdx.org/licenses/Jam.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Jam.json",
-      "referenceNumber": 48,
+      "referenceNumber": 410,
       "name": "Jam License",
       "licenseId": "Jam",
       "seeAlso": [
@@ -4515,7 +4516,7 @@
       "reference": "https://spdx.org/licenses/JasPer-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": 406,
+      "referenceNumber": 316,
       "name": "JasPer License",
       "licenseId": "JasPer-2.0",
       "seeAlso": [
@@ -4527,7 +4528,7 @@
       "reference": "https://spdx.org/licenses/JPL-image.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPL-image.json",
-      "referenceNumber": 179,
+      "referenceNumber": 193,
       "name": "JPL Image Use Policy",
       "licenseId": "JPL-image",
       "seeAlso": [
@@ -4539,7 +4540,7 @@
       "reference": "https://spdx.org/licenses/JPNIC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JPNIC.json",
-      "referenceNumber": 80,
+      "referenceNumber": 140,
       "name": "Japan Network Information Center License",
       "licenseId": "JPNIC",
       "seeAlso": [
@@ -4551,7 +4552,7 @@
       "reference": "https://spdx.org/licenses/JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/JSON.json",
-      "referenceNumber": 485,
+      "referenceNumber": 667,
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -4564,7 +4565,7 @@
       "reference": "https://spdx.org/licenses/Kastrup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kastrup.json",
-      "referenceNumber": 124,
+      "referenceNumber": 468,
       "name": "Kastrup License",
       "licenseId": "Kastrup",
       "seeAlso": [
@@ -4576,7 +4577,7 @@
       "reference": "https://spdx.org/licenses/Kazlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Kazlib.json",
-      "referenceNumber": 233,
+      "referenceNumber": 72,
       "name": "Kazlib License",
       "licenseId": "Kazlib",
       "seeAlso": [
@@ -4588,7 +4589,7 @@
       "reference": "https://spdx.org/licenses/Knuth-CTAN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Knuth-CTAN.json",
-      "referenceNumber": 287,
+      "referenceNumber": 513,
       "name": "Knuth CTAN License",
       "licenseId": "Knuth-CTAN",
       "seeAlso": [
@@ -4600,7 +4601,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": 469,
+      "referenceNumber": 490,
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -4612,7 +4613,7 @@
       "reference": "https://spdx.org/licenses/LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": 553,
+      "referenceNumber": 364,
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
@@ -4624,7 +4625,7 @@
       "reference": "https://spdx.org/licenses/Latex2e.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": 11,
+      "referenceNumber": 84,
       "name": "Latex2e License",
       "licenseId": "Latex2e",
       "seeAlso": [
@@ -4636,7 +4637,7 @@
       "reference": "https://spdx.org/licenses/Latex2e-translated-notice.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Latex2e-translated-notice.json",
-      "referenceNumber": 352,
+      "referenceNumber": 27,
       "name": "Latex2e with translated notice permission",
       "licenseId": "Latex2e-translated-notice",
       "seeAlso": [
@@ -4648,7 +4649,7 @@
       "reference": "https://spdx.org/licenses/Leptonica.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": 600,
+      "referenceNumber": 388,
       "name": "Leptonica License",
       "licenseId": "Leptonica",
       "seeAlso": [
@@ -4660,7 +4661,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": 244,
+      "referenceNumber": 672,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0",
       "seeAlso": [
@@ -4672,7 +4673,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": 172,
+      "referenceNumber": 411,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0+",
       "seeAlso": [
@@ -4684,7 +4685,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": 77,
+      "referenceNumber": 233,
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
@@ -4696,7 +4697,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": 470,
+      "referenceNumber": 168,
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
@@ -4708,7 +4709,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": 120,
+      "referenceNumber": 206,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1",
       "seeAlso": [
@@ -4722,7 +4723,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": 403,
+      "referenceNumber": 566,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1+",
       "seeAlso": [
@@ -4736,7 +4737,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": 119,
+      "referenceNumber": 59,
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
@@ -4750,7 +4751,7 @@
       "reference": "https://spdx.org/licenses/LGPL-2.1-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": 559,
+      "referenceNumber": 98,
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
@@ -4764,7 +4765,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": 627,
+      "referenceNumber": 372,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0",
       "seeAlso": [
@@ -4779,7 +4780,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0+.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": 13,
+      "referenceNumber": 405,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0+",
       "seeAlso": [
@@ -4794,7 +4795,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": 480,
+      "referenceNumber": 263,
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
@@ -4809,7 +4810,7 @@
       "reference": "https://spdx.org/licenses/LGPL-3.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": 602,
+      "referenceNumber": 291,
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
@@ -4824,7 +4825,7 @@
       "reference": "https://spdx.org/licenses/LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": 589,
+      "referenceNumber": 78,
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -4836,7 +4837,7 @@
       "reference": "https://spdx.org/licenses/Libpng.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Libpng.json",
-      "referenceNumber": 464,
+      "referenceNumber": 648,
       "name": "libpng License",
       "licenseId": "Libpng",
       "seeAlso": [
@@ -4848,7 +4849,7 @@
       "reference": "https://spdx.org/licenses/libpng-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libpng-2.0.json",
-      "referenceNumber": 147,
+      "referenceNumber": 390,
       "name": "PNG Reference Library version 2",
       "licenseId": "libpng-2.0",
       "seeAlso": [
@@ -4860,7 +4861,7 @@
       "reference": "https://spdx.org/licenses/libselinux-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libselinux-1.0.json",
-      "referenceNumber": 495,
+      "referenceNumber": 404,
       "name": "libselinux public domain notice",
       "licenseId": "libselinux-1.0",
       "seeAlso": [
@@ -4872,7 +4873,7 @@
       "reference": "https://spdx.org/licenses/libtiff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libtiff.json",
-      "referenceNumber": 204,
+      "referenceNumber": 589,
       "name": "libtiff License",
       "licenseId": "libtiff",
       "seeAlso": [
@@ -4884,7 +4885,7 @@
       "reference": "https://spdx.org/licenses/libutil-David-Nugent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/libutil-David-Nugent.json",
-      "referenceNumber": 42,
+      "referenceNumber": 201,
       "name": "libutil David Nugent License",
       "licenseId": "libutil-David-Nugent",
       "seeAlso": [
@@ -4897,7 +4898,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-P-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": 34,
+      "referenceNumber": 288,
       "name": "Licence Libre du Québec – Permissive version 1.1",
       "licenseId": "LiLiQ-P-1.1",
       "seeAlso": [
@@ -4910,7 +4911,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-R-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": 542,
+      "referenceNumber": 353,
       "name": "Licence Libre du Québec – Réciprocité version 1.1",
       "licenseId": "LiLiQ-R-1.1",
       "seeAlso": [
@@ -4923,7 +4924,7 @@
       "reference": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": 268,
+      "referenceNumber": 222,
       "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
       "licenseId": "LiLiQ-Rplus-1.1",
       "seeAlso": [
@@ -4936,7 +4937,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-1-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-1-para.json",
-      "referenceNumber": 668,
+      "referenceNumber": 417,
       "name": "Linux man-pages - 1 paragraph",
       "licenseId": "Linux-man-pages-1-para",
       "seeAlso": [
@@ -4948,7 +4949,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft.json",
-      "referenceNumber": 299,
+      "referenceNumber": 587,
       "name": "Linux man-pages Copyleft",
       "licenseId": "Linux-man-pages-copyleft",
       "seeAlso": [
@@ -4960,7 +4961,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-2-para.json",
-      "referenceNumber": 393,
+      "referenceNumber": 631,
       "name": "Linux man-pages Copyleft - 2 paragraphs",
       "licenseId": "Linux-man-pages-copyleft-2-para",
       "seeAlso": [
@@ -4973,7 +4974,7 @@
       "reference": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-man-pages-copyleft-var.json",
-      "referenceNumber": 482,
+      "referenceNumber": 480,
       "name": "Linux man-pages Copyleft Variant",
       "licenseId": "Linux-man-pages-copyleft-var",
       "seeAlso": [
@@ -4985,7 +4986,7 @@
       "reference": "https://spdx.org/licenses/Linux-OpenIB.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": 185,
+      "referenceNumber": 384,
       "name": "Linux Kernel Variant of OpenIB.org license",
       "licenseId": "Linux-OpenIB",
       "seeAlso": [
@@ -4997,7 +4998,7 @@
       "reference": "https://spdx.org/licenses/LOOP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LOOP.json",
-      "referenceNumber": 663,
+      "referenceNumber": 132,
       "name": "Common Lisp LOOP License",
       "licenseId": "LOOP",
       "seeAlso": [
@@ -5014,7 +5015,7 @@
       "reference": "https://spdx.org/licenses/LPD-document.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPD-document.json",
-      "referenceNumber": 569,
+      "referenceNumber": 422,
       "name": "LPD Documentation License",
       "licenseId": "LPD-document",
       "seeAlso": [
@@ -5027,7 +5028,7 @@
       "reference": "https://spdx.org/licenses/LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": 340,
+      "referenceNumber": 534,
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
@@ -5039,7 +5040,7 @@
       "reference": "https://spdx.org/licenses/LPL-1.02.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": 155,
+      "referenceNumber": 268,
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
@@ -5053,7 +5054,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": 560,
+      "referenceNumber": 654,
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -5065,7 +5066,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": 447,
+      "referenceNumber": 538,
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -5077,7 +5078,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": 487,
+      "referenceNumber": 103,
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -5090,7 +5091,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3a.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": 607,
+      "referenceNumber": 526,
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -5103,7 +5104,7 @@
       "reference": "https://spdx.org/licenses/LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": 122,
+      "referenceNumber": 8,
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
@@ -5116,7 +5117,7 @@
       "reference": "https://spdx.org/licenses/lsof.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/lsof.json",
-      "referenceNumber": 424,
+      "referenceNumber": 254,
       "name": "lsof License",
       "licenseId": "lsof",
       "seeAlso": [
@@ -5128,7 +5129,7 @@
       "reference": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Lucida-Bitmap-Fonts.json",
-      "referenceNumber": 6,
+      "referenceNumber": 329,
       "name": "Lucida Bitmap Fonts License",
       "licenseId": "Lucida-Bitmap-Fonts",
       "seeAlso": [
@@ -5140,7 +5141,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.11-to-9.20.json",
-      "referenceNumber": 571,
+      "referenceNumber": 146,
       "name": "LZMA SDK License (versions 9.11 to 9.20)",
       "licenseId": "LZMA-SDK-9.11-to-9.20",
       "seeAlso": [
@@ -5153,7 +5154,7 @@
       "reference": "https://spdx.org/licenses/LZMA-SDK-9.22.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/LZMA-SDK-9.22.json",
-      "referenceNumber": 609,
+      "referenceNumber": 445,
       "name": "LZMA SDK License (versions 9.22 and beyond)",
       "licenseId": "LZMA-SDK-9.22",
       "seeAlso": [
@@ -5166,7 +5167,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause.json",
-      "referenceNumber": 484,
+      "referenceNumber": 503,
       "name": "Mackerras 3-Clause License",
       "licenseId": "Mackerras-3-Clause",
       "seeAlso": [
@@ -5178,7 +5179,7 @@
       "reference": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mackerras-3-Clause-acknowledgment.json",
-      "referenceNumber": 330,
+      "referenceNumber": 576,
       "name": "Mackerras 3-Clause - acknowledgment variant",
       "licenseId": "Mackerras-3-Clause-acknowledgment",
       "seeAlso": [
@@ -5190,7 +5191,7 @@
       "reference": "https://spdx.org/licenses/magaz.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/magaz.json",
-      "referenceNumber": 104,
+      "referenceNumber": 218,
       "name": "magaz License",
       "licenseId": "magaz",
       "seeAlso": [
@@ -5202,7 +5203,7 @@
       "reference": "https://spdx.org/licenses/mailprio.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mailprio.json",
-      "referenceNumber": 465,
+      "referenceNumber": 63,
       "name": "mailprio License",
       "licenseId": "mailprio",
       "seeAlso": [
@@ -5214,7 +5215,7 @@
       "reference": "https://spdx.org/licenses/MakeIndex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": 608,
+      "referenceNumber": 552,
       "name": "MakeIndex License",
       "licenseId": "MakeIndex",
       "seeAlso": [
@@ -5226,7 +5227,7 @@
       "reference": "https://spdx.org/licenses/Martin-Birgmeier.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Martin-Birgmeier.json",
-      "referenceNumber": 228,
+      "referenceNumber": 182,
       "name": "Martin Birgmeier License",
       "licenseId": "Martin-Birgmeier",
       "seeAlso": [
@@ -5238,7 +5239,7 @@
       "reference": "https://spdx.org/licenses/McPhee-slideshow.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/McPhee-slideshow.json",
-      "referenceNumber": 207,
+      "referenceNumber": 177,
       "name": "McPhee Slideshow License",
       "licenseId": "McPhee-slideshow",
       "seeAlso": [
@@ -5250,7 +5251,7 @@
       "reference": "https://spdx.org/licenses/metamail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/metamail.json",
-      "referenceNumber": 132,
+      "referenceNumber": 508,
       "name": "metamail License",
       "licenseId": "metamail",
       "seeAlso": [
@@ -5262,7 +5263,7 @@
       "reference": "https://spdx.org/licenses/Minpack.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Minpack.json",
-      "referenceNumber": 676,
+      "referenceNumber": 609,
       "name": "Minpack License",
       "licenseId": "Minpack",
       "seeAlso": [
@@ -5272,10 +5273,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/MIPS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/MIPS.json",
+      "referenceNumber": 556,
+      "name": "MIPS License",
+      "licenseId": "MIPS",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/sym.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/MirOS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MirOS.json",
-      "referenceNumber": 279,
+      "referenceNumber": 10,
       "name": "The MirOS Licence",
       "licenseId": "MirOS",
       "seeAlso": [
@@ -5287,7 +5300,7 @@
       "reference": "https://spdx.org/licenses/MIT.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT.json",
-      "referenceNumber": 541,
+      "referenceNumber": 143,
       "name": "MIT License",
       "licenseId": "MIT",
       "seeAlso": [
@@ -5300,7 +5313,7 @@
       "reference": "https://spdx.org/licenses/MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": 176,
+      "referenceNumber": 71,
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -5314,7 +5327,7 @@
       "reference": "https://spdx.org/licenses/MIT-advertising.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-advertising.json",
-      "referenceNumber": 473,
+      "referenceNumber": 246,
       "name": "Enlightenment License (e16)",
       "licenseId": "MIT-advertising",
       "seeAlso": [
@@ -5326,7 +5339,7 @@
       "reference": "https://spdx.org/licenses/MIT-Click.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Click.json",
-      "referenceNumber": 271,
+      "referenceNumber": 374,
       "name": "MIT Click License",
       "licenseId": "MIT-Click",
       "seeAlso": [
@@ -5338,7 +5351,7 @@
       "reference": "https://spdx.org/licenses/MIT-CMU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": 435,
+      "referenceNumber": 467,
       "name": "CMU License",
       "licenseId": "MIT-CMU",
       "seeAlso": [
@@ -5351,7 +5364,7 @@
       "reference": "https://spdx.org/licenses/MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": 178,
+      "referenceNumber": 195,
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -5363,7 +5376,7 @@
       "reference": "https://spdx.org/licenses/MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": 414,
+      "referenceNumber": 221,
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -5375,7 +5388,7 @@
       "reference": "https://spdx.org/licenses/MIT-Festival.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Festival.json",
-      "referenceNumber": 116,
+      "referenceNumber": 229,
       "name": "MIT Festival Variant",
       "licenseId": "MIT-Festival",
       "seeAlso": [
@@ -5388,7 +5401,7 @@
       "reference": "https://spdx.org/licenses/MIT-Khronos-old.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Khronos-old.json",
-      "referenceNumber": 293,
+      "referenceNumber": 341,
       "name": "MIT Khronos - old variant",
       "licenseId": "MIT-Khronos-old",
       "seeAlso": [
@@ -5400,7 +5413,7 @@
       "reference": "https://spdx.org/licenses/MIT-Modern-Variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Modern-Variant.json",
-      "referenceNumber": 307,
+      "referenceNumber": 580,
       "name": "MIT License Modern Variant",
       "licenseId": "MIT-Modern-Variant",
       "seeAlso": [
@@ -5414,7 +5427,7 @@
       "reference": "https://spdx.org/licenses/MIT-open-group.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-open-group.json",
-      "referenceNumber": 125,
+      "referenceNumber": 646,
       "name": "MIT Open Group variant",
       "licenseId": "MIT-open-group",
       "seeAlso": [
@@ -5429,7 +5442,7 @@
       "reference": "https://spdx.org/licenses/MIT-testregex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-testregex.json",
-      "referenceNumber": 623,
+      "referenceNumber": 135,
       "name": "MIT testregex Variant",
       "licenseId": "MIT-testregex",
       "seeAlso": [
@@ -5441,7 +5454,7 @@
       "reference": "https://spdx.org/licenses/MIT-Wu.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MIT-Wu.json",
-      "referenceNumber": 494,
+      "referenceNumber": 459,
       "name": "MIT Tom Wu Variant",
       "licenseId": "MIT-Wu",
       "seeAlso": [
@@ -5453,7 +5466,7 @@
       "reference": "https://spdx.org/licenses/MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": 629,
+      "referenceNumber": 588,
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -5465,7 +5478,7 @@
       "reference": "https://spdx.org/licenses/MMIXware.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MMIXware.json",
-      "referenceNumber": 349,
+      "referenceNumber": 53,
       "name": "MMIXware License",
       "licenseId": "MMIXware",
       "seeAlso": [
@@ -5477,7 +5490,7 @@
       "reference": "https://spdx.org/licenses/Motosoto.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": 272,
+      "referenceNumber": 207,
       "name": "Motosoto License",
       "licenseId": "Motosoto",
       "seeAlso": [
@@ -5489,7 +5502,7 @@
       "reference": "https://spdx.org/licenses/MPEG-SSG.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPEG-SSG.json",
-      "referenceNumber": 181,
+      "referenceNumber": 597,
       "name": "MPEG Software Simulation",
       "licenseId": "MPEG-SSG",
       "seeAlso": [
@@ -5501,7 +5514,7 @@
       "reference": "https://spdx.org/licenses/mpi-permissive.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpi-permissive.json",
-      "referenceNumber": 556,
+      "referenceNumber": 471,
       "name": "mpi Permissive License",
       "licenseId": "mpi-permissive",
       "seeAlso": [
@@ -5513,7 +5526,7 @@
       "reference": "https://spdx.org/licenses/mpich2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mpich2.json",
-      "referenceNumber": 509,
+      "referenceNumber": 117,
       "name": "mpich2 License",
       "licenseId": "mpich2",
       "seeAlso": [
@@ -5525,7 +5538,7 @@
       "reference": "https://spdx.org/licenses/MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": 649,
+      "referenceNumber": 34,
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
@@ -5538,7 +5551,7 @@
       "reference": "https://spdx.org/licenses/MPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": 152,
+      "referenceNumber": 26,
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
@@ -5552,7 +5565,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": 361,
+      "referenceNumber": 249,
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
@@ -5566,7 +5579,7 @@
       "reference": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": 328,
+      "referenceNumber": 351,
       "name": "Mozilla Public License 2.0 (no copyleft exception)",
       "licenseId": "MPL-2.0-no-copyleft-exception",
       "seeAlso": [
@@ -5579,7 +5592,7 @@
       "reference": "https://spdx.org/licenses/mplus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/mplus.json",
-      "referenceNumber": 171,
+      "referenceNumber": 85,
       "name": "mplus Font License",
       "licenseId": "mplus",
       "seeAlso": [
@@ -5591,7 +5604,7 @@
       "reference": "https://spdx.org/licenses/MS-LPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-LPL.json",
-      "referenceNumber": 598,
+      "referenceNumber": 370,
       "name": "Microsoft Limited Public License",
       "licenseId": "MS-LPL",
       "seeAlso": [
@@ -5605,7 +5618,7 @@
       "reference": "https://spdx.org/licenses/MS-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": 531,
+      "referenceNumber": 429,
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
@@ -5619,7 +5632,7 @@
       "reference": "https://spdx.org/licenses/MS-RL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": 516,
+      "referenceNumber": 394,
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
@@ -5633,7 +5646,7 @@
       "reference": "https://spdx.org/licenses/MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MTLL.json",
-      "referenceNumber": 341,
+      "referenceNumber": 620,
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -5645,7 +5658,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-1.0.json",
-      "referenceNumber": 117,
+      "referenceNumber": 600,
       "name": "Mulan Permissive Software License, Version 1",
       "licenseId": "MulanPSL-1.0",
       "seeAlso": [
@@ -5658,7 +5671,7 @@
       "reference": "https://spdx.org/licenses/MulanPSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/MulanPSL-2.0.json",
-      "referenceNumber": 374,
+      "referenceNumber": 310,
       "name": "Mulan Permissive Software License, Version 2",
       "licenseId": "MulanPSL-2.0",
       "seeAlso": [
@@ -5670,7 +5683,7 @@
       "reference": "https://spdx.org/licenses/Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Multics.json",
-      "referenceNumber": 38,
+      "referenceNumber": 676,
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
@@ -5682,7 +5695,7 @@
       "reference": "https://spdx.org/licenses/Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Mup.json",
-      "referenceNumber": 520,
+      "referenceNumber": 371,
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -5694,7 +5707,7 @@
       "reference": "https://spdx.org/licenses/NAIST-2003.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NAIST-2003.json",
-      "referenceNumber": 532,
+      "referenceNumber": 244,
       "name": "Nara Institute of Science and Technology License (2003)",
       "licenseId": "NAIST-2003",
       "seeAlso": [
@@ -5707,7 +5720,7 @@
       "reference": "https://spdx.org/licenses/NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": 53,
+      "referenceNumber": 486,
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
@@ -5721,7 +5734,7 @@
       "reference": "https://spdx.org/licenses/Naumen.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Naumen.json",
-      "referenceNumber": 355,
+      "referenceNumber": 594,
       "name": "Naumen Public License",
       "licenseId": "Naumen",
       "seeAlso": [
@@ -5733,7 +5746,7 @@
       "reference": "https://spdx.org/licenses/NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": 162,
+      "referenceNumber": 240,
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -5745,7 +5758,7 @@
       "reference": "https://spdx.org/licenses/NCBI-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCBI-PD.json",
-      "referenceNumber": 247,
+      "referenceNumber": 397,
       "name": "NCBI Public Domain Notice",
       "licenseId": "NCBI-PD",
       "seeAlso": [
@@ -5761,7 +5774,7 @@
       "reference": "https://spdx.org/licenses/NCGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCGL-UK-2.0.json",
-      "referenceNumber": 49,
+      "referenceNumber": 211,
       "name": "Non-Commercial Government Licence",
       "licenseId": "NCGL-UK-2.0",
       "seeAlso": [
@@ -5773,7 +5786,7 @@
       "reference": "https://spdx.org/licenses/NCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCL.json",
-      "referenceNumber": 449,
+      "referenceNumber": 158,
       "name": "NCL Source Code License",
       "licenseId": "NCL",
       "seeAlso": [
@@ -5785,7 +5798,7 @@
       "reference": "https://spdx.org/licenses/NCSA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NCSA.json",
-      "referenceNumber": 527,
+      "referenceNumber": 478,
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
@@ -5799,7 +5812,7 @@
       "reference": "https://spdx.org/licenses/Net-SNMP.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": 431,
+      "referenceNumber": 440,
       "name": "Net-SNMP License",
       "licenseId": "Net-SNMP",
       "seeAlso": [
@@ -5811,7 +5824,7 @@
       "reference": "https://spdx.org/licenses/NetCDF.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": 622,
+      "referenceNumber": 302,
       "name": "NetCDF license",
       "licenseId": "NetCDF",
       "seeAlso": [
@@ -5823,7 +5836,7 @@
       "reference": "https://spdx.org/licenses/Newsletr.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": 186,
+      "referenceNumber": 162,
       "name": "Newsletr License",
       "licenseId": "Newsletr",
       "seeAlso": [
@@ -5835,7 +5848,7 @@
       "reference": "https://spdx.org/licenses/NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NGPL.json",
-      "referenceNumber": 642,
+      "referenceNumber": 115,
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
@@ -5847,7 +5860,7 @@
       "reference": "https://spdx.org/licenses/NICTA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NICTA-1.0.json",
-      "referenceNumber": 54,
+      "referenceNumber": 536,
       "name": "NICTA Public Software License, Version 1.0",
       "licenseId": "NICTA-1.0",
       "seeAlso": [
@@ -5859,7 +5872,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD.json",
-      "referenceNumber": 14,
+      "referenceNumber": 1,
       "name": "NIST Public Domain Notice",
       "licenseId": "NIST-PD",
       "seeAlso": [
@@ -5872,7 +5885,7 @@
       "reference": "https://spdx.org/licenses/NIST-PD-fallback.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-PD-fallback.json",
-      "referenceNumber": 222,
+      "referenceNumber": 463,
       "name": "NIST Public Domain Notice with license fallback",
       "licenseId": "NIST-PD-fallback",
       "seeAlso": [
@@ -5885,7 +5898,7 @@
       "reference": "https://spdx.org/licenses/NIST-Software.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NIST-Software.json",
-      "referenceNumber": 254,
+      "referenceNumber": 460,
       "name": "NIST Software License",
       "licenseId": "NIST-Software",
       "seeAlso": [
@@ -5897,7 +5910,7 @@
       "reference": "https://spdx.org/licenses/NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": 193,
+      "referenceNumber": 3,
       "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -5909,7 +5922,7 @@
       "reference": "https://spdx.org/licenses/NLOD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLOD-2.0.json",
-      "referenceNumber": 323,
+      "referenceNumber": 60,
       "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
       "licenseId": "NLOD-2.0",
       "seeAlso": [
@@ -5921,7 +5934,7 @@
       "reference": "https://spdx.org/licenses/NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NLPL.json",
-      "referenceNumber": 593,
+      "referenceNumber": 477,
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -5933,7 +5946,7 @@
       "reference": "https://spdx.org/licenses/Nokia.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Nokia.json",
-      "referenceNumber": 165,
+      "referenceNumber": 601,
       "name": "Nokia Open Source License",
       "licenseId": "Nokia",
       "seeAlso": [
@@ -5946,7 +5959,7 @@
       "reference": "https://spdx.org/licenses/NOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NOSL.json",
-      "referenceNumber": 90,
+      "referenceNumber": 86,
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -5959,7 +5972,7 @@
       "reference": "https://spdx.org/licenses/Noweb.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Noweb.json",
-      "referenceNumber": 30,
+      "referenceNumber": 64,
       "name": "Noweb License",
       "licenseId": "Noweb",
       "seeAlso": [
@@ -5971,7 +5984,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": 17,
+      "referenceNumber": 189,
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -5984,7 +5997,7 @@
       "reference": "https://spdx.org/licenses/NPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": 215,
+      "referenceNumber": 491,
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -5997,7 +6010,7 @@
       "reference": "https://spdx.org/licenses/NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": 674,
+      "referenceNumber": 507,
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
@@ -6009,7 +6022,7 @@
       "reference": "https://spdx.org/licenses/NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NRL.json",
-      "referenceNumber": 442,
+      "referenceNumber": 444,
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -6021,7 +6034,7 @@
       "reference": "https://spdx.org/licenses/NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP.json",
-      "referenceNumber": 226,
+      "referenceNumber": 541,
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
@@ -6033,7 +6046,7 @@
       "reference": "https://spdx.org/licenses/NTP-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/NTP-0.json",
-      "referenceNumber": 35,
+      "referenceNumber": 586,
       "name": "NTP No Attribution",
       "licenseId": "NTP-0",
       "seeAlso": [
@@ -6045,7 +6058,7 @@
       "reference": "https://spdx.org/licenses/Nunit.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/Nunit.json",
-      "referenceNumber": 216,
+      "referenceNumber": 605,
       "name": "Nunit License",
       "licenseId": "Nunit",
       "seeAlso": [
@@ -6058,7 +6071,7 @@
       "reference": "https://spdx.org/licenses/O-UDA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/O-UDA-1.0.json",
-      "referenceNumber": 290,
+      "referenceNumber": 82,
       "name": "Open Use of Data Agreement v1.0",
       "licenseId": "O-UDA-1.0",
       "seeAlso": [
@@ -6071,7 +6084,7 @@
       "reference": "https://spdx.org/licenses/OAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OAR.json",
-      "referenceNumber": 376,
+      "referenceNumber": 77,
       "name": "OAR License",
       "licenseId": "OAR",
       "seeAlso": [
@@ -6083,7 +6096,7 @@
       "reference": "https://spdx.org/licenses/OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": 404,
+      "referenceNumber": 549,
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -6095,7 +6108,7 @@
       "reference": "https://spdx.org/licenses/OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": 506,
+      "referenceNumber": 230,
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
@@ -6108,7 +6121,7 @@
       "reference": "https://spdx.org/licenses/ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": 562,
+      "referenceNumber": 607,
       "name": "Open Data Commons Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
@@ -6122,7 +6135,7 @@
       "reference": "https://spdx.org/licenses/ODC-By-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ODC-By-1.0.json",
-      "referenceNumber": 440,
+      "referenceNumber": 235,
       "name": "Open Data Commons Attribution License v1.0",
       "licenseId": "ODC-By-1.0",
       "seeAlso": [
@@ -6134,7 +6147,7 @@
       "reference": "https://spdx.org/licenses/OFFIS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFFIS.json",
-      "referenceNumber": 356,
+      "referenceNumber": 427,
       "name": "OFFIS License",
       "licenseId": "OFFIS",
       "seeAlso": [
@@ -6146,7 +6159,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": 370,
+      "referenceNumber": 99,
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
       "seeAlso": [
@@ -6159,7 +6172,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-no-RFN.json",
-      "referenceNumber": 93,
+      "referenceNumber": 363,
       "name": "SIL Open Font License 1.0 with no Reserved Font Name",
       "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
@@ -6171,7 +6184,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.0-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.0-RFN.json",
-      "referenceNumber": 546,
+      "referenceNumber": 622,
       "name": "SIL Open Font License 1.0 with Reserved Font Name",
       "licenseId": "OFL-1.0-RFN",
       "seeAlso": [
@@ -6183,7 +6196,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": 105,
+      "referenceNumber": 430,
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
@@ -6197,7 +6210,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-no-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-no-RFN.json",
-      "referenceNumber": 62,
+      "referenceNumber": 562,
       "name": "SIL Open Font License 1.1 with no Reserved Font Name",
       "licenseId": "OFL-1.1-no-RFN",
       "seeAlso": [
@@ -6210,7 +6223,7 @@
       "reference": "https://spdx.org/licenses/OFL-1.1-RFN.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OFL-1.1-RFN.json",
-      "referenceNumber": 258,
+      "referenceNumber": 87,
       "name": "SIL Open Font License 1.1 with Reserved Font Name",
       "licenseId": "OFL-1.1-RFN",
       "seeAlso": [
@@ -6223,7 +6236,7 @@
       "reference": "https://spdx.org/licenses/OGC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGC-1.0.json",
-      "referenceNumber": 661,
+      "referenceNumber": 528,
       "name": "OGC Software License, Version 1.0",
       "licenseId": "OGC-1.0",
       "seeAlso": [
@@ -6235,7 +6248,7 @@
       "reference": "https://spdx.org/licenses/OGDL-Taiwan-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGDL-Taiwan-1.0.json",
-      "referenceNumber": 267,
+      "referenceNumber": 253,
       "name": "Taiwan Open Government Data License, version 1.0",
       "licenseId": "OGDL-Taiwan-1.0",
       "seeAlso": [
@@ -6247,7 +6260,7 @@
       "reference": "https://spdx.org/licenses/OGL-Canada-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-Canada-2.0.json",
-      "referenceNumber": 430,
+      "referenceNumber": 441,
       "name": "Open Government Licence - Canada",
       "licenseId": "OGL-Canada-2.0",
       "seeAlso": [
@@ -6259,7 +6272,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-1.0.json",
-      "referenceNumber": 448,
+      "referenceNumber": 172,
       "name": "Open Government Licence v1.0",
       "licenseId": "OGL-UK-1.0",
       "seeAlso": [
@@ -6271,7 +6284,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-2.0.json",
-      "referenceNumber": 412,
+      "referenceNumber": 400,
       "name": "Open Government Licence v2.0",
       "licenseId": "OGL-UK-2.0",
       "seeAlso": [
@@ -6283,7 +6296,7 @@
       "reference": "https://spdx.org/licenses/OGL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGL-UK-3.0.json",
-      "referenceNumber": 576,
+      "referenceNumber": 385,
       "name": "Open Government Licence v3.0",
       "licenseId": "OGL-UK-3.0",
       "seeAlso": [
@@ -6295,7 +6308,7 @@
       "reference": "https://spdx.org/licenses/OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": 68,
+      "referenceNumber": 614,
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
@@ -6308,7 +6321,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": 123,
+      "referenceNumber": 208,
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -6320,7 +6333,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": 407,
+      "referenceNumber": 36,
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -6332,7 +6345,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": 488,
+      "referenceNumber": 58,
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -6344,7 +6357,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": 282,
+      "referenceNumber": 505,
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -6356,7 +6369,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": 573,
+      "referenceNumber": 260,
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -6368,7 +6381,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": 422,
+      "referenceNumber": 634,
       "name": "Open LDAP Public License v2.0.1",
       "licenseId": "OLDAP-2.0.1",
       "seeAlso": [
@@ -6380,7 +6393,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": 306,
+      "referenceNumber": 187,
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -6392,7 +6405,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": 26,
+      "referenceNumber": 366,
       "name": "Open LDAP Public License v2.2",
       "licenseId": "OLDAP-2.2",
       "seeAlso": [
@@ -6404,7 +6417,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": 78,
+      "referenceNumber": 535,
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -6416,7 +6429,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": 615,
+      "referenceNumber": 127,
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -6428,7 +6441,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": 263,
+      "referenceNumber": 298,
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -6441,7 +6454,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": 305,
+      "referenceNumber": 359,
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -6453,7 +6466,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": 397,
+      "referenceNumber": 185,
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -6465,7 +6478,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": 334,
+      "referenceNumber": 545,
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -6477,7 +6490,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.7.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": 476,
+      "referenceNumber": 618,
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -6490,7 +6503,7 @@
       "reference": "https://spdx.org/licenses/OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": 371,
+      "referenceNumber": 14,
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
@@ -6502,7 +6515,7 @@
       "reference": "https://spdx.org/licenses/OLFL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OLFL-1.3.json",
-      "referenceNumber": 91,
+      "referenceNumber": 352,
       "name": "Open Logistics Foundation License Version 1.3",
       "licenseId": "OLFL-1.3",
       "seeAlso": [
@@ -6515,7 +6528,7 @@
       "reference": "https://spdx.org/licenses/OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OML.json",
-      "referenceNumber": 584,
+      "referenceNumber": 453,
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -6527,7 +6540,7 @@
       "reference": "https://spdx.org/licenses/OpenPBS-2.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenPBS-2.3.json",
-      "referenceNumber": 513,
+      "referenceNumber": 20,
       "name": "OpenPBS v2.3 Software License",
       "licenseId": "OpenPBS-2.3",
       "seeAlso": [
@@ -6540,7 +6553,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": 315,
+      "referenceNumber": 393,
       "name": "OpenSSL License",
       "licenseId": "OpenSSL",
       "seeAlso": [
@@ -6553,7 +6566,7 @@
       "reference": "https://spdx.org/licenses/OpenSSL-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenSSL-standalone.json",
-      "referenceNumber": 84,
+      "referenceNumber": 334,
       "name": "OpenSSL License - standalone",
       "licenseId": "OpenSSL-standalone",
       "seeAlso": [
@@ -6566,7 +6579,7 @@
       "reference": "https://spdx.org/licenses/OpenVision.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OpenVision.json",
-      "referenceNumber": 89,
+      "referenceNumber": 22,
       "name": "OpenVision License",
       "licenseId": "OpenVision",
       "seeAlso": [
@@ -6580,7 +6593,7 @@
       "reference": "https://spdx.org/licenses/OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": 377,
+      "referenceNumber": 43,
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -6594,7 +6607,7 @@
       "reference": "https://spdx.org/licenses/OPL-UK-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPL-UK-3.0.json",
-      "referenceNumber": 368,
+      "referenceNumber": 251,
       "name": "United    Kingdom Open Parliament Licence v3.0",
       "licenseId": "OPL-UK-3.0",
       "seeAlso": [
@@ -6606,7 +6619,7 @@
       "reference": "https://spdx.org/licenses/OPUBL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OPUBL-1.0.json",
-      "referenceNumber": 455,
+      "referenceNumber": 239,
       "name": "Open Publication License v1.0",
       "licenseId": "OPUBL-1.0",
       "seeAlso": [
@@ -6620,7 +6633,7 @@
       "reference": "https://spdx.org/licenses/OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": 312,
+      "referenceNumber": 664,
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
@@ -6633,7 +6646,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": 236,
+      "referenceNumber": 561,
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
@@ -6646,7 +6659,7 @@
       "reference": "https://spdx.org/licenses/OSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": 324,
+      "referenceNumber": 481,
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -6659,7 +6672,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": 199,
+      "referenceNumber": 437,
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -6672,7 +6685,7 @@
       "reference": "https://spdx.org/licenses/OSL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": 498,
+      "referenceNumber": 368,
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
@@ -6686,7 +6699,7 @@
       "reference": "https://spdx.org/licenses/OSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": 64,
+      "referenceNumber": 42,
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
@@ -6700,7 +6713,7 @@
       "reference": "https://spdx.org/licenses/PADL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PADL.json",
-      "referenceNumber": 180,
+      "referenceNumber": 533,
       "name": "PADL License",
       "licenseId": "PADL",
       "seeAlso": [
@@ -6712,7 +6725,7 @@
       "reference": "https://spdx.org/licenses/Parity-6.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-6.0.0.json",
-      "referenceNumber": 212,
+      "referenceNumber": 13,
       "name": "The Parity Public License 6.0.0",
       "licenseId": "Parity-6.0.0",
       "seeAlso": [
@@ -6724,7 +6737,7 @@
       "reference": "https://spdx.org/licenses/Parity-7.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Parity-7.0.0.json",
-      "referenceNumber": 284,
+      "referenceNumber": 324,
       "name": "The Parity Public License 7.0.0",
       "licenseId": "Parity-7.0.0",
       "seeAlso": [
@@ -6736,7 +6749,7 @@
       "reference": "https://spdx.org/licenses/PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": 351,
+      "referenceNumber": 150,
       "name": "Open Data Commons Public Domain Dedication \u0026 License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
@@ -6749,7 +6762,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": 203,
+      "referenceNumber": 138,
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
@@ -6762,7 +6775,7 @@
       "reference": "https://spdx.org/licenses/PHP-3.01.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": 50,
+      "referenceNumber": 666,
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
@@ -6775,7 +6788,7 @@
       "reference": "https://spdx.org/licenses/Pixar.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Pixar.json",
-      "referenceNumber": 51,
+      "referenceNumber": 603,
       "name": "Pixar License",
       "licenseId": "Pixar",
       "seeAlso": [
@@ -6789,7 +6802,7 @@
       "reference": "https://spdx.org/licenses/pkgconf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pkgconf.json",
-      "referenceNumber": 551,
+      "referenceNumber": 663,
       "name": "pkgconf License",
       "licenseId": "pkgconf",
       "seeAlso": [
@@ -6801,7 +6814,7 @@
       "reference": "https://spdx.org/licenses/Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Plexus.json",
-      "referenceNumber": 662,
+      "referenceNumber": 180,
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -6813,7 +6826,7 @@
       "reference": "https://spdx.org/licenses/pnmstitch.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/pnmstitch.json",
-      "referenceNumber": 651,
+      "referenceNumber": 294,
       "name": "pnmstitch License",
       "licenseId": "pnmstitch",
       "seeAlso": [
@@ -6825,7 +6838,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
-      "referenceNumber": 656,
+      "referenceNumber": 570,
       "name": "PolyForm Noncommercial License 1.0.0",
       "licenseId": "PolyForm-Noncommercial-1.0.0",
       "seeAlso": [
@@ -6837,7 +6850,7 @@
       "reference": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
-      "referenceNumber": 167,
+      "referenceNumber": 157,
       "name": "PolyForm Small Business License 1.0.0",
       "licenseId": "PolyForm-Small-Business-1.0.0",
       "seeAlso": [
@@ -6849,7 +6862,7 @@
       "reference": "https://spdx.org/licenses/PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": 309,
+      "referenceNumber": 653,
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
@@ -6862,7 +6875,7 @@
       "reference": "https://spdx.org/licenses/PPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PPL.json",
-      "referenceNumber": 259,
+      "referenceNumber": 125,
       "name": "Peer Production License",
       "licenseId": "PPL",
       "seeAlso": [
@@ -6876,7 +6889,7 @@
       "reference": "https://spdx.org/licenses/PSF-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/PSF-2.0.json",
-      "referenceNumber": 76,
+      "referenceNumber": 479,
       "name": "Python Software Foundation License 2.0",
       "licenseId": "PSF-2.0",
       "seeAlso": [
@@ -6889,7 +6902,7 @@
       "reference": "https://spdx.org/licenses/psfrag.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psfrag.json",
-      "referenceNumber": 210,
+      "referenceNumber": 88,
       "name": "psfrag License",
       "licenseId": "psfrag",
       "seeAlso": [
@@ -6901,7 +6914,7 @@
       "reference": "https://spdx.org/licenses/psutils.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/psutils.json",
-      "referenceNumber": 45,
+      "referenceNumber": 54,
       "name": "psutils License",
       "licenseId": "psutils",
       "seeAlso": [
@@ -6913,7 +6926,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": 197,
+      "referenceNumber": 651,
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
@@ -6926,7 +6939,7 @@
       "reference": "https://spdx.org/licenses/Python-2.0.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Python-2.0.1.json",
-      "referenceNumber": 221,
+      "referenceNumber": 292,
       "name": "Python License 2.0.1",
       "licenseId": "Python-2.0.1",
       "seeAlso": [
@@ -6940,7 +6953,7 @@
       "reference": "https://spdx.org/licenses/python-ldap.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/python-ldap.json",
-      "referenceNumber": 243,
+      "referenceNumber": 537,
       "name": "Python ldap License",
       "licenseId": "python-ldap",
       "seeAlso": [
@@ -6952,7 +6965,7 @@
       "reference": "https://spdx.org/licenses/Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Qhull.json",
-      "referenceNumber": 230,
+      "referenceNumber": 434,
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -6964,7 +6977,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": 149,
+      "referenceNumber": 169,
       "name": "Q Public License 1.0",
       "licenseId": "QPL-1.0",
       "seeAlso": [
@@ -6979,7 +6992,7 @@
       "reference": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/QPL-1.0-INRIA-2004.json",
-      "referenceNumber": 507,
+      "referenceNumber": 461,
       "name": "Q Public License 1.0 - INRIA 2004 variant",
       "licenseId": "QPL-1.0-INRIA-2004",
       "seeAlso": [
@@ -6991,7 +7004,7 @@
       "reference": "https://spdx.org/licenses/radvd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/radvd.json",
-      "referenceNumber": 452,
+      "referenceNumber": 425,
       "name": "radvd License",
       "licenseId": "radvd",
       "seeAlso": [
@@ -7003,7 +7016,7 @@
       "reference": "https://spdx.org/licenses/Rdisc.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": 295,
+      "referenceNumber": 74,
       "name": "Rdisc License",
       "licenseId": "Rdisc",
       "seeAlso": [
@@ -7015,7 +7028,7 @@
       "reference": "https://spdx.org/licenses/RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": 373,
+      "referenceNumber": 12,
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -7028,7 +7041,7 @@
       "reference": "https://spdx.org/licenses/RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": 79,
+      "referenceNumber": 281,
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
@@ -7040,7 +7053,7 @@
       "reference": "https://spdx.org/licenses/RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": 63,
+      "referenceNumber": 599,
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
@@ -7052,7 +7065,7 @@
       "reference": "https://spdx.org/licenses/RPSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": 515,
+      "referenceNumber": 671,
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
@@ -7066,7 +7079,7 @@
       "reference": "https://spdx.org/licenses/RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": 289,
+      "referenceNumber": 178,
       "name": "RSA Message-Digest License",
       "licenseId": "RSA-MD",
       "seeAlso": [
@@ -7078,7 +7091,7 @@
       "reference": "https://spdx.org/licenses/RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": 319,
+      "referenceNumber": 6,
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
@@ -7091,7 +7104,7 @@
       "reference": "https://spdx.org/licenses/Ruby.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby.json",
-      "referenceNumber": 69,
+      "referenceNumber": 380,
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -7104,7 +7117,7 @@
       "reference": "https://spdx.org/licenses/Ruby-pty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ruby-pty.json",
-      "referenceNumber": 399,
+      "referenceNumber": 559,
       "name": "Ruby pty extension license",
       "licenseId": "Ruby-pty",
       "seeAlso": [
@@ -7118,7 +7131,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": 248,
+      "referenceNumber": 166,
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -7130,7 +7143,7 @@
       "reference": "https://spdx.org/licenses/SAX-PD-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SAX-PD-2.0.json",
-      "referenceNumber": 316,
+      "referenceNumber": 497,
       "name": "Sax Public Domain Notice 2.0",
       "licenseId": "SAX-PD-2.0",
       "seeAlso": [
@@ -7142,7 +7155,7 @@
       "reference": "https://spdx.org/licenses/Saxpath.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": 67,
+      "referenceNumber": 283,
       "name": "Saxpath License",
       "licenseId": "Saxpath",
       "seeAlso": [
@@ -7154,7 +7167,7 @@
       "reference": "https://spdx.org/licenses/SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SCEA.json",
-      "referenceNumber": 385,
+      "referenceNumber": 487,
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -7166,7 +7179,7 @@
       "reference": "https://spdx.org/licenses/SchemeReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SchemeReport.json",
-      "referenceNumber": 545,
+      "referenceNumber": 339,
       "name": "Scheme Language Report License",
       "licenseId": "SchemeReport",
       "seeAlso": [],
@@ -7176,7 +7189,7 @@
       "reference": "https://spdx.org/licenses/Sendmail.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": 296,
+      "referenceNumber": 389,
       "name": "Sendmail License",
       "licenseId": "Sendmail",
       "seeAlso": [
@@ -7189,7 +7202,7 @@
       "reference": "https://spdx.org/licenses/Sendmail-8.23.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail-8.23.json",
-      "referenceNumber": 605,
+      "referenceNumber": 148,
       "name": "Sendmail License 8.23",
       "licenseId": "Sendmail-8.23",
       "seeAlso": [
@@ -7202,7 +7215,7 @@
       "reference": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sendmail-Open-Source-1.1.json",
-      "referenceNumber": 543,
+      "referenceNumber": 554,
       "name": "Sendmail Open Source License v1.1",
       "licenseId": "Sendmail-Open-Source-1.1",
       "seeAlso": [
@@ -7214,7 +7227,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": 139,
+      "referenceNumber": 515,
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -7226,7 +7239,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": 594,
+      "referenceNumber": 50,
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -7238,7 +7251,7 @@
       "reference": "https://spdx.org/licenses/SGI-B-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": 304,
+      "referenceNumber": 551,
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -7251,7 +7264,7 @@
       "reference": "https://spdx.org/licenses/SGI-OpenGL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGI-OpenGL.json",
-      "referenceNumber": 378,
+      "referenceNumber": 76,
       "name": "SGI OpenGL License",
       "licenseId": "SGI-OpenGL",
       "seeAlso": [
@@ -7263,7 +7276,7 @@
       "reference": "https://spdx.org/licenses/SGP4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SGP4.json",
-      "referenceNumber": 112,
+      "referenceNumber": 23,
       "name": "SGP4 Permission Notice",
       "licenseId": "SGP4",
       "seeAlso": [
@@ -7275,7 +7288,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.5.json",
-      "referenceNumber": 251,
+      "referenceNumber": 149,
       "name": "Solderpad Hardware License v0.5",
       "licenseId": "SHL-0.5",
       "seeAlso": [
@@ -7287,7 +7300,7 @@
       "reference": "https://spdx.org/licenses/SHL-0.51.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SHL-0.51.json",
-      "referenceNumber": 599,
+      "referenceNumber": 512,
       "name": "Solderpad Hardware License, Version 0.51",
       "licenseId": "SHL-0.51",
       "seeAlso": [
@@ -7299,7 +7312,7 @@
       "reference": "https://spdx.org/licenses/SimPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": 457,
+      "referenceNumber": 568,
       "name": "Simple Public License 2.0",
       "licenseId": "SimPL-2.0",
       "seeAlso": [
@@ -7311,7 +7324,7 @@
       "reference": "https://spdx.org/licenses/SISSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL.json",
-      "referenceNumber": 33,
+      "referenceNumber": 349,
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
@@ -7325,7 +7338,7 @@
       "reference": "https://spdx.org/licenses/SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": 492,
+      "referenceNumber": 670,
       "name": "Sun Industry Standards Source License v1.2",
       "licenseId": "SISSL-1.2",
       "seeAlso": [
@@ -7337,7 +7350,7 @@
       "reference": "https://spdx.org/licenses/SL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SL.json",
-      "referenceNumber": 344,
+      "referenceNumber": 295,
       "name": "SL License",
       "licenseId": "SL",
       "seeAlso": [
@@ -7349,7 +7362,7 @@
       "reference": "https://spdx.org/licenses/Sleepycat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": 428,
+      "referenceNumber": 120,
       "name": "Sleepycat License",
       "licenseId": "Sleepycat",
       "seeAlso": [
@@ -7362,7 +7375,7 @@
       "reference": "https://spdx.org/licenses/SMAIL-GPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMAIL-GPL.json",
-      "referenceNumber": 106,
+      "referenceNumber": 485,
       "name": "SMAIL General Public License",
       "licenseId": "SMAIL-GPL",
       "seeAlso": [
@@ -7374,7 +7387,7 @@
       "reference": "https://spdx.org/licenses/SMLNJ.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": 521,
+      "referenceNumber": 506,
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -7387,7 +7400,7 @@
       "reference": "https://spdx.org/licenses/SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": 36,
+      "referenceNumber": 325,
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -7399,7 +7412,7 @@
       "reference": "https://spdx.org/licenses/SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SNIA.json",
-      "referenceNumber": 73,
+      "referenceNumber": 91,
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -7411,7 +7424,7 @@
       "reference": "https://spdx.org/licenses/snprintf.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/snprintf.json",
-      "referenceNumber": 264,
+      "referenceNumber": 442,
       "name": "snprintf License",
       "licenseId": "snprintf",
       "seeAlso": [
@@ -7423,7 +7436,7 @@
       "reference": "https://spdx.org/licenses/softSurfer.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/softSurfer.json",
-      "referenceNumber": 610,
+      "referenceNumber": 97,
       "name": "softSurfer License",
       "licenseId": "softSurfer",
       "seeAlso": [
@@ -7436,7 +7449,7 @@
       "reference": "https://spdx.org/licenses/Soundex.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Soundex.json",
-      "referenceNumber": 113,
+      "referenceNumber": 65,
       "name": "Soundex License",
       "licenseId": "Soundex",
       "seeAlso": [
@@ -7448,7 +7461,7 @@
       "reference": "https://spdx.org/licenses/Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": 217,
+      "referenceNumber": 21,
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -7460,7 +7473,7 @@
       "reference": "https://spdx.org/licenses/Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": 213,
+      "referenceNumber": 472,
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -7473,7 +7486,7 @@
       "reference": "https://spdx.org/licenses/Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": 303,
+      "referenceNumber": 432,
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -7485,7 +7498,7 @@
       "reference": "https://spdx.org/licenses/SPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": 277,
+      "referenceNumber": 474,
       "name": "Sun Public License v1.0",
       "licenseId": "SPL-1.0",
       "seeAlso": [
@@ -7498,7 +7511,7 @@
       "reference": "https://spdx.org/licenses/ssh-keyscan.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ssh-keyscan.json",
-      "referenceNumber": 398,
+      "referenceNumber": 431,
       "name": "ssh-keyscan License",
       "licenseId": "ssh-keyscan",
       "seeAlso": [
@@ -7510,7 +7523,7 @@
       "reference": "https://spdx.org/licenses/SSH-OpenSSH.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-OpenSSH.json",
-      "referenceNumber": 357,
+      "referenceNumber": 70,
       "name": "SSH OpenSSH license",
       "licenseId": "SSH-OpenSSH",
       "seeAlso": [
@@ -7522,7 +7535,7 @@
       "reference": "https://spdx.org/licenses/SSH-short.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSH-short.json",
-      "referenceNumber": 114,
+      "referenceNumber": 170,
       "name": "SSH short notice",
       "licenseId": "SSH-short",
       "seeAlso": [
@@ -7536,7 +7549,7 @@
       "reference": "https://spdx.org/licenses/SSLeay-standalone.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSLeay-standalone.json",
-      "referenceNumber": 637,
+      "referenceNumber": 32,
       "name": "SSLeay License - standalone",
       "licenseId": "SSLeay-standalone",
       "seeAlso": [
@@ -7548,7 +7561,7 @@
       "reference": "https://spdx.org/licenses/SSPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SSPL-1.0.json",
-      "referenceNumber": 300,
+      "referenceNumber": 633,
       "name": "Server Side Public License, v 1",
       "licenseId": "SSPL-1.0",
       "seeAlso": [
@@ -7560,7 +7573,7 @@
       "reference": "https://spdx.org/licenses/StandardML-NJ.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": 677,
+      "referenceNumber": 278,
       "name": "Standard ML of New Jersey License",
       "licenseId": "StandardML-NJ",
       "seeAlso": [
@@ -7573,7 +7586,7 @@
       "reference": "https://spdx.org/licenses/SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": 383,
+      "referenceNumber": 192,
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -7585,7 +7598,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP.json",
-      "referenceNumber": 586,
+      "referenceNumber": 544,
       "name": "Sun PPP License",
       "licenseId": "Sun-PPP",
       "seeAlso": [
@@ -7597,7 +7610,7 @@
       "reference": "https://spdx.org/licenses/Sun-PPP-2000.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Sun-PPP-2000.json",
-      "referenceNumber": 475,
+      "referenceNumber": 514,
       "name": "Sun PPP License (2000)",
       "licenseId": "Sun-PPP-2000",
       "seeAlso": [
@@ -7609,7 +7622,7 @@
       "reference": "https://spdx.org/licenses/SunPro.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SunPro.json",
-      "referenceNumber": 347,
+      "referenceNumber": 255,
       "name": "SunPro License",
       "licenseId": "SunPro",
       "seeAlso": [
@@ -7622,7 +7635,7 @@
       "reference": "https://spdx.org/licenses/SWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/SWL.json",
-      "referenceNumber": 325,
+      "referenceNumber": 655,
       "name": "Scheme Widget Library (SWL) Software License Agreement",
       "licenseId": "SWL",
       "seeAlso": [
@@ -7634,7 +7647,7 @@
       "reference": "https://spdx.org/licenses/swrule.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/swrule.json",
-      "referenceNumber": 519,
+      "referenceNumber": 282,
       "name": "swrule License",
       "licenseId": "swrule",
       "seeAlso": [
@@ -7646,7 +7659,7 @@
       "reference": "https://spdx.org/licenses/Symlinks.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Symlinks.json",
-      "referenceNumber": 278,
+      "referenceNumber": 558,
       "name": "Symlinks License",
       "licenseId": "Symlinks",
       "seeAlso": [
@@ -7658,7 +7671,7 @@
       "reference": "https://spdx.org/licenses/TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TAPR-OHL-1.0.json",
-      "referenceNumber": 567,
+      "referenceNumber": 241,
       "name": "TAPR Open Hardware License v1.0",
       "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
@@ -7670,7 +7683,7 @@
       "reference": "https://spdx.org/licenses/TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCL.json",
-      "referenceNumber": 472,
+      "referenceNumber": 673,
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -7683,7 +7696,7 @@
       "reference": "https://spdx.org/licenses/TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": 211,
+      "referenceNumber": 126,
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -7695,7 +7708,7 @@
       "reference": "https://spdx.org/licenses/TermReadKey.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TermReadKey.json",
-      "referenceNumber": 558,
+      "referenceNumber": 640,
       "name": "TermReadKey License",
       "licenseId": "TermReadKey",
       "seeAlso": [
@@ -7707,7 +7720,7 @@
       "reference": "https://spdx.org/licenses/TGPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TGPPL-1.0.json",
-      "referenceNumber": 548,
+      "referenceNumber": 314,
       "name": "Transitive Grace Period Public Licence 1.0",
       "licenseId": "TGPPL-1.0",
       "seeAlso": [
@@ -7717,10 +7730,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "https://spdx.org/licenses/ThirdEye.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "https://spdx.org/licenses/ThirdEye.json",
+      "referenceNumber": 320,
+      "name": "ThirdEye License",
+      "licenseId": "ThirdEye",
+      "seeAlso": [
+        "https://sourceware.org/cgit/binutils-gdb/tree/include/coff/symconst.h#n11"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "https://spdx.org/licenses/threeparttable.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/threeparttable.json",
-      "referenceNumber": 366,
+      "referenceNumber": 369,
       "name": "threeparttable License",
       "licenseId": "threeparttable",
       "seeAlso": [
@@ -7732,7 +7757,7 @@
       "reference": "https://spdx.org/licenses/TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TMate.json",
-      "referenceNumber": 401,
+      "referenceNumber": 160,
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -7744,7 +7769,7 @@
       "reference": "https://spdx.org/licenses/TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": 493,
+      "referenceNumber": 498,
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -7756,7 +7781,7 @@
       "reference": "https://spdx.org/licenses/TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TOSL.json",
-      "referenceNumber": 156,
+      "referenceNumber": 639,
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -7768,7 +7793,7 @@
       "reference": "https://spdx.org/licenses/TPDL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPDL.json",
-      "referenceNumber": 32,
+      "referenceNumber": 443,
       "name": "Time::ParseDate License",
       "licenseId": "TPDL",
       "seeAlso": [
@@ -7780,7 +7805,7 @@
       "reference": "https://spdx.org/licenses/TPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TPL-1.0.json",
-      "referenceNumber": 133,
+      "referenceNumber": 267,
       "name": "THOR Public License 1.0",
       "licenseId": "TPL-1.0",
       "seeAlso": [
@@ -7792,7 +7817,7 @@
       "reference": "https://spdx.org/licenses/TrustedQSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TrustedQSL.json",
-      "referenceNumber": 417,
+      "referenceNumber": 395,
       "name": "TrustedQSL License",
       "licenseId": "TrustedQSL",
       "seeAlso": [
@@ -7804,7 +7829,7 @@
       "reference": "https://spdx.org/licenses/TTWL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTWL.json",
-      "referenceNumber": 382,
+      "referenceNumber": 112,
       "name": "Text-Tabs+Wrap License",
       "licenseId": "TTWL",
       "seeAlso": [
@@ -7817,7 +7842,7 @@
       "reference": "https://spdx.org/licenses/TTYP0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TTYP0.json",
-      "referenceNumber": 380,
+      "referenceNumber": 336,
       "name": "TTYP0 License",
       "licenseId": "TTYP0",
       "seeAlso": [
@@ -7829,7 +7854,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-1.0.json",
-      "referenceNumber": 588,
+      "referenceNumber": 296,
       "name": "Technische Universitaet Berlin License 1.0",
       "licenseId": "TU-Berlin-1.0",
       "seeAlso": [
@@ -7841,7 +7866,7 @@
       "reference": "https://spdx.org/licenses/TU-Berlin-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/TU-Berlin-2.0.json",
-      "referenceNumber": 565,
+      "referenceNumber": 499,
       "name": "Technische Universitaet Berlin License 2.0",
       "licenseId": "TU-Berlin-2.0",
       "seeAlso": [
@@ -7853,7 +7878,7 @@
       "reference": "https://spdx.org/licenses/Ubuntu-font-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Ubuntu-font-1.0.json",
-      "referenceNumber": 333,
+      "referenceNumber": 73,
       "name": "Ubuntu Font Licence v1.0",
       "licenseId": "Ubuntu-font-1.0",
       "seeAlso": [
@@ -7866,7 +7891,7 @@
       "reference": "https://spdx.org/licenses/UCAR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCAR.json",
-      "referenceNumber": 164,
+      "referenceNumber": 560,
       "name": "UCAR License",
       "licenseId": "UCAR",
       "seeAlso": [
@@ -7878,7 +7903,7 @@
       "reference": "https://spdx.org/licenses/UCL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UCL-1.0.json",
-      "referenceNumber": 451,
+      "referenceNumber": 619,
       "name": "Upstream Compatibility License v1.0",
       "licenseId": "UCL-1.0",
       "seeAlso": [
@@ -7890,7 +7915,7 @@
       "reference": "https://spdx.org/licenses/ulem.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ulem.json",
-      "referenceNumber": 338,
+      "referenceNumber": 502,
       "name": "ulem License",
       "licenseId": "ulem",
       "seeAlso": [
@@ -7902,7 +7927,7 @@
       "reference": "https://spdx.org/licenses/UMich-Merit.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UMich-Merit.json",
-      "referenceNumber": 101,
+      "referenceNumber": 217,
       "name": "Michigan/Merit Networks License",
       "licenseId": "UMich-Merit",
       "seeAlso": [
@@ -7914,7 +7939,7 @@
       "reference": "https://spdx.org/licenses/Unicode-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-3.0.json",
-      "referenceNumber": 388,
+      "referenceNumber": 447,
       "name": "Unicode License v3",
       "licenseId": "Unicode-3.0",
       "seeAlso": [
@@ -7926,7 +7951,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": 655,
+      "referenceNumber": 79,
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -7938,7 +7963,7 @@
       "reference": "https://spdx.org/licenses/Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": 22,
+      "referenceNumber": 665,
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
@@ -7952,7 +7977,7 @@
       "reference": "https://spdx.org/licenses/Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": 416,
+      "referenceNumber": 573,
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -7965,7 +7990,7 @@
       "reference": "https://spdx.org/licenses/UnixCrypt.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UnixCrypt.json",
-      "referenceNumber": 135,
+      "referenceNumber": 259,
       "name": "UnixCrypt License",
       "licenseId": "UnixCrypt",
       "seeAlso": [
@@ -7979,7 +8004,7 @@
       "reference": "https://spdx.org/licenses/Unlicense.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": 225,
+      "referenceNumber": 165,
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
@@ -7992,7 +8017,7 @@
       "reference": "https://spdx.org/licenses/UPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": 522,
+      "referenceNumber": 342,
       "name": "Universal Permissive License v1.0",
       "licenseId": "UPL-1.0",
       "seeAlso": [
@@ -8005,7 +8030,7 @@
       "reference": "https://spdx.org/licenses/URT-RLE.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/URT-RLE.json",
-      "referenceNumber": 128,
+      "referenceNumber": 524,
       "name": "Utah Raster Toolkit Run Length Encoded License",
       "licenseId": "URT-RLE",
       "seeAlso": [
@@ -8018,7 +8043,7 @@
       "reference": "https://spdx.org/licenses/Vim.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Vim.json",
-      "referenceNumber": 621,
+      "referenceNumber": 49,
       "name": "Vim License",
       "licenseId": "Vim",
       "seeAlso": [
@@ -8031,7 +8056,7 @@
       "reference": "https://spdx.org/licenses/VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": 463,
+      "referenceNumber": 439,
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -8043,7 +8068,7 @@
       "reference": "https://spdx.org/licenses/VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": 261,
+      "referenceNumber": 242,
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
@@ -8055,7 +8080,7 @@
       "reference": "https://spdx.org/licenses/W3C.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C.json",
-      "referenceNumber": 86,
+      "referenceNumber": 236,
       "name": "W3C Software Notice and License (2002-12-31)",
       "licenseId": "W3C",
       "seeAlso": [
@@ -8069,7 +8094,7 @@
       "reference": "https://spdx.org/licenses/W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": 71,
+      "referenceNumber": 219,
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -8081,7 +8106,7 @@
       "reference": "https://spdx.org/licenses/W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": 427,
+      "referenceNumber": 375,
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -8095,7 +8120,7 @@
       "reference": "https://spdx.org/licenses/w3m.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/w3m.json",
-      "referenceNumber": 433,
+      "referenceNumber": 81,
       "name": "w3m License",
       "licenseId": "w3m",
       "seeAlso": [
@@ -8107,7 +8132,7 @@
       "reference": "https://spdx.org/licenses/Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": 555,
+      "referenceNumber": 322,
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
@@ -8120,7 +8145,7 @@
       "reference": "https://spdx.org/licenses/Widget-Workshop.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Widget-Workshop.json",
-      "referenceNumber": 285,
+      "referenceNumber": 656,
       "name": "Widget Workshop License",
       "licenseId": "Widget-Workshop",
       "seeAlso": [
@@ -8132,7 +8157,7 @@
       "reference": "https://spdx.org/licenses/Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": 601,
+      "referenceNumber": 399,
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -8144,7 +8169,7 @@
       "reference": "https://spdx.org/licenses/WTFPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": 107,
+      "referenceNumber": 247,
       "name": "Do What The F*ck You Want To Public License",
       "licenseId": "WTFPL",
       "seeAlso": [
@@ -8158,7 +8183,7 @@
       "reference": "https://spdx.org/licenses/wwl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/wwl.json",
-      "referenceNumber": 419,
+      "referenceNumber": 109,
       "name": "WWL License",
       "licenseId": "wwl",
       "seeAlso": [
@@ -8170,7 +8195,7 @@
       "reference": "https://spdx.org/licenses/wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "https://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": 670,
+      "referenceNumber": 147,
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
@@ -8182,7 +8207,7 @@
       "reference": "https://spdx.org/licenses/X11.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11.json",
-      "referenceNumber": 353,
+      "referenceNumber": 306,
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -8195,7 +8220,7 @@
       "reference": "https://spdx.org/licenses/X11-distribute-modifications-variant.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-distribute-modifications-variant.json",
-      "referenceNumber": 505,
+      "referenceNumber": 307,
       "name": "X11 License Distribution Modification Variant",
       "licenseId": "X11-distribute-modifications-variant",
       "seeAlso": [
@@ -8207,7 +8232,7 @@
       "reference": "https://spdx.org/licenses/X11-swapped.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/X11-swapped.json",
-      "referenceNumber": 671,
+      "referenceNumber": 159,
       "name": "X11 swapped final paragraphs",
       "licenseId": "X11-swapped",
       "seeAlso": [
@@ -8219,7 +8244,7 @@
       "reference": "https://spdx.org/licenses/Xdebug-1.03.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xdebug-1.03.json",
-      "referenceNumber": 453,
+      "referenceNumber": 408,
       "name": "Xdebug License v 1.03",
       "licenseId": "Xdebug-1.03",
       "seeAlso": [
@@ -8231,7 +8256,7 @@
       "reference": "https://spdx.org/licenses/Xerox.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xerox.json",
-      "referenceNumber": 158,
+      "referenceNumber": 577,
       "name": "Xerox License",
       "licenseId": "Xerox",
       "seeAlso": [
@@ -8243,7 +8268,7 @@
       "reference": "https://spdx.org/licenses/Xfig.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xfig.json",
-      "referenceNumber": 619,
+      "referenceNumber": 469,
       "name": "Xfig License",
       "licenseId": "Xfig",
       "seeAlso": [
@@ -8257,7 +8282,7 @@
       "reference": "https://spdx.org/licenses/XFree86-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": 645,
+      "referenceNumber": 47,
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -8270,7 +8295,7 @@
       "reference": "https://spdx.org/licenses/xinetd.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xinetd.json",
-      "referenceNumber": 219,
+      "referenceNumber": 414,
       "name": "xinetd License",
       "licenseId": "xinetd",
       "seeAlso": [
@@ -8283,7 +8308,7 @@
       "reference": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xkeyboard-config-Zinoviev.json",
-      "referenceNumber": 227,
+      "referenceNumber": 446,
       "name": "xkeyboard-config Zinoviev License",
       "licenseId": "xkeyboard-config-Zinoviev",
       "seeAlso": [
@@ -8295,7 +8320,7 @@
       "reference": "https://spdx.org/licenses/xlock.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xlock.json",
-      "referenceNumber": 392,
+      "referenceNumber": 516,
       "name": "xlock License",
       "licenseId": "xlock",
       "seeAlso": [
@@ -8307,7 +8332,7 @@
       "reference": "https://spdx.org/licenses/Xnet.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Xnet.json",
-      "referenceNumber": 438,
+      "referenceNumber": 367,
       "name": "X.Net License",
       "licenseId": "Xnet",
       "seeAlso": [
@@ -8319,7 +8344,7 @@
       "reference": "https://spdx.org/licenses/xpp.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xpp.json",
-      "referenceNumber": 503,
+      "referenceNumber": 48,
       "name": "XPP License",
       "licenseId": "xpp",
       "seeAlso": [
@@ -8331,7 +8356,7 @@
       "reference": "https://spdx.org/licenses/XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/XSkat.json",
-      "referenceNumber": 109,
+      "referenceNumber": 145,
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -8343,7 +8368,7 @@
       "reference": "https://spdx.org/licenses/xzoom.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/xzoom.json",
-      "referenceNumber": 664,
+      "referenceNumber": 644,
       "name": "xzoom License",
       "licenseId": "xzoom",
       "seeAlso": [
@@ -8355,7 +8380,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": 500,
+      "referenceNumber": 547,
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -8367,7 +8392,7 @@
       "reference": "https://spdx.org/licenses/YPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": 190,
+      "referenceNumber": 679,
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -8380,7 +8405,7 @@
       "reference": "https://spdx.org/licenses/Zed.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zed.json",
-      "referenceNumber": 460,
+      "referenceNumber": 555,
       "name": "Zed License",
       "licenseId": "Zed",
       "seeAlso": [
@@ -8392,7 +8417,7 @@
       "reference": "https://spdx.org/licenses/Zeeff.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zeeff.json",
-      "referenceNumber": 595,
+      "referenceNumber": 391,
       "name": "Zeeff License",
       "licenseId": "Zeeff",
       "seeAlso": [
@@ -8404,7 +8429,7 @@
       "reference": "https://spdx.org/licenses/Zend-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": 245,
+      "referenceNumber": 335,
       "name": "Zend License v2.0",
       "licenseId": "Zend-2.0",
       "seeAlso": [
@@ -8417,7 +8442,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": 327,
+      "referenceNumber": 450,
       "name": "Zimbra Public License v1.3",
       "licenseId": "Zimbra-1.3",
       "seeAlso": [
@@ -8430,7 +8455,7 @@
       "reference": "https://spdx.org/licenses/Zimbra-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": 12,
+      "referenceNumber": 257,
       "name": "Zimbra Public License v1.4",
       "licenseId": "Zimbra-1.4",
       "seeAlso": [
@@ -8442,7 +8467,7 @@
       "reference": "https://spdx.org/licenses/Zlib.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/Zlib.json",
-      "referenceNumber": 110,
+      "referenceNumber": 563,
       "name": "zlib License",
       "licenseId": "Zlib",
       "seeAlso": [
@@ -8456,7 +8481,7 @@
       "reference": "https://spdx.org/licenses/zlib-acknowledgement.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": 362,
+      "referenceNumber": 11,
       "name": "zlib/libpng License with Acknowledgement",
       "licenseId": "zlib-acknowledgement",
       "seeAlso": [
@@ -8468,7 +8493,7 @@
       "reference": "https://spdx.org/licenses/ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": 510,
+      "referenceNumber": 313,
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -8480,7 +8505,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": 173,
+      "referenceNumber": 623,
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
@@ -8494,7 +8519,7 @@
       "reference": "https://spdx.org/licenses/ZPL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "https://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": 657,
+      "referenceNumber": 111,
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -8504,5 +8529,5 @@
       "isFsfLibre": true
     }
   ],
-  "releaseDate": "2024-11-16"
+  "releaseDate": "2025-01-05T00:00:00Z"
 }


### PR DESCRIPTION
Updates the SPDX license list to the latest from https://raw.githubusercontent.com/spdx/license-list-data/refs/heads/main/json/licenses.json