### PR TITLE
Use the module homepage as a website externalReference in the components output

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,17 @@ The `listBom` command can be used to generate the contents of the BOM without wr
 
 ### configuration
 
-| Setting                | Type    | Default                                                                | Description                                                    |
-|------------------------|---------|------------------------------------------------------------------------|----------------------------------------------------------------|
-| bomFileName            | String  | `"${artifactId}-${artifactVersion}.bom.xml"`                           | bom file name                                                  |
-| bomFormat              | String  | `json` or `xml`, defaults to the format of bomFileName or else `json`  | bom format                                                     |
-| bomSchemaVersion       | String  | `"1.6"`                                                                | bom schema version                                             |
-| includeBomSerialNumber | Boolean | `false`                                                                | include serial number in bom                                   |
-| includeBomTimestamp    | Boolean | `false`                                                                | include timestamp in bom                                       |
-| includeBomToolVersion  | Boolean | `true`                                                                 | include tool version in bom                                    |
-| includeBomHashes       | Boolean | `true`                                                                 | include artifact hashes in bom                                 |
-| enableBomSha3Hashes    | Boolean | `true`                                                                 | enable the generation of sha3 hashes (not available on java 8) |
+| Setting                      | Type    | Default                                                                | Description                                                    |
+|------------------------------|---------|------------------------------------------------------------------------|----------------------------------------------------------------|
+| bomFileName                  | String  | `"${artifactId}-${artifactVersion}.bom.xml"`                           | bom file name                                                  |
+| bomFormat                    | String  | `json` or `xml`, defaults to the format of bomFileName or else `json`  | bom format                                                     |
+| bomSchemaVersion             | String  | `"1.6"`                                                                | bom schema version                                             |
+| includeBomSerialNumber       | Boolean | `false`                                                                | include serial number in bom                                   |
+| includeBomTimestamp          | Boolean | `false`                                                                | include timestamp in bom                                       |
+| includeBomToolVersion        | Boolean | `true`                                                                 | include tool version in bom                                    |
+| includeBomHashes             | Boolean | `true`                                                                 | include artifact hashes in bom                                 |
+| enableBomSha3Hashes          | Boolean | `true`                                                                 | enable the generation of sha3 hashes (not available on java 8) |
+| includeBomExternalReferences | Boolean | `true`                                                                 | include external references in bom                             |
 
 Sample configuration:
 

--- a/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
@@ -7,7 +7,7 @@ package com.github.sbt.sbom
 import com.github.packageurl.PackageURL
 import com.github.sbt.sbom.licenses.LicensesArchive
 import org.cyclonedx.Version
-import org.cyclonedx.model.{ Bom, Component, Hash, License, LicenseChoice, Metadata, Tool }
+import org.cyclonedx.model.{ Bom, Component, ExternalReference, Hash, License, LicenseChoice, Metadata, Tool }
 import org.cyclonedx.util.BomUtils
 import sbt._
 import sbt.librarymanagement.ModuleReport
@@ -126,6 +126,14 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, log: Logg
         component.setHashes(hashes(artifactPaths(moduleReport)).asJava)
       }
       licenseChoice.foreach(component.setLicenses)
+      if (settings.includeBomExternalReferences && settings.schemaVersion.getVersion >= Version.VERSION_11.getVersion) {
+        moduleReport.homepage.foreach { url =>
+          val homepage = new ExternalReference()
+          homepage.setType(ExternalReference.Type.WEBSITE)
+          homepage.setUrl(url)
+          component.addExternalReference(homepage)
+        }
+      }
 
       /*
         not returned component properties are (BOM version 1.0):

--- a/src/main/scala/com/github/sbt/sbom/BomExtractorParams.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractorParams.scala
@@ -15,4 +15,5 @@ final case class BomExtractorParams(
     includeBomToolVersion: Boolean,
     includeBomHashes: Boolean,
     enableBomSha3Hashes: Boolean,
+    includeBomExternalReferences: Boolean,
 )

--- a/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
@@ -44,6 +44,9 @@ object BomSbtPlugin extends AutoPlugin {
     lazy val enableBomSha3Hashes: SettingKey[Boolean] = settingKey[Boolean](
       "should the resulting BOM artifact hashes contain sha3 hashes? default is true"
     )
+    lazy val includeBomExternalReferences: SettingKey[Boolean] = settingKey[Boolean](
+      "should the resulting BOM contain external references? default is true"
+    )
     lazy val makeBom: TaskKey[sbt.File] = taskKey[sbt.File]("Generates bom file")
     lazy val listBom: TaskKey[String] = taskKey[String]("Returns the bom")
     lazy val components: TaskKey[Component] = taskKey[Component]("Returns the bom")
@@ -71,6 +74,7 @@ object BomSbtPlugin extends AutoPlugin {
       includeBomToolVersion := true,
       includeBomHashes := true,
       enableBomSha3Hashes := true,
+      includeBomExternalReferences := true,
       makeBom := Def.taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, Compile)).value,
       listBom := Def.taskDyn(BomSbtSettings.listBomTask(Classpaths.updateTask.value, Compile)).value,
       Test / makeBom := Def.taskDyn(BomSbtSettings.makeBomTask(Classpaths.updateTask.value, Test)).value,

--- a/src/main/scala/com/github/sbt/sbom/BomSbtSettings.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtSettings.scala
@@ -27,7 +27,8 @@ object BomSbtSettings {
           includeBomTimestamp.value,
           includeBomToolVersion.value,
           includeBomHashes.value,
-          enableBomSha3Hashes.value
+          enableBomSha3Hashes.value,
+          includeBomExternalReferences.value,
         ),
         target.value / (currentConfiguration / bomFileName).value
       ).execute
@@ -51,7 +52,8 @@ object BomSbtSettings {
           includeBomTimestamp.value,
           includeBomToolVersion.value,
           includeBomHashes.value,
-          enableBomSha3Hashes.value
+          enableBomSha3Hashes.value,
+          includeBomExternalReferences.value,
         )
       ).execute
     }

--- a/src/main/scala/com/github/sbt/sbom/BomTask.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomTask.scala
@@ -26,6 +26,7 @@ final case class BomTaskProperties(
     includeBomToolVersion: Boolean,
     includeBomHashes: Boolean,
     enableBomSha3Hashes: Boolean,
+    includeBomExternalReferences: Boolean,
 )
 
 abstract class BomTask[T](protected val properties: BomTaskProperties) {
@@ -78,7 +79,8 @@ abstract class BomTask[T](protected val properties: BomTaskProperties) {
       includeBomTimestamp,
       includeBomToolVersion,
       includeBomHashes,
-      enableBomSha3Hashes
+      enableBomSha3Hashes,
+      includeBomExternalReferences,
     )
 
   protected def logBomInfo(params: BomExtractorParams, bom: Bom): Unit = {
@@ -113,4 +115,6 @@ abstract class BomTask[T](protected val properties: BomTaskProperties) {
   protected lazy val includeBomHashes: Boolean = properties.includeBomHashes
 
   protected lazy val enableBomSha3Hashes: Boolean = properties.enableBomSha3Hashes
+
+  protected lazy val includeBomExternalReferences: Boolean = properties.includeBomExternalReferences
 }

--- a/src/sbt-test/dependencies/compile/etc/bom.xml
+++ b/src/sbt-test/dependencies/compile/etc/bom.xml
@@ -28,6 +28,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-core_2.12@0.10.0">
       <group>io.circe</group>
@@ -49,6 +54,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-generic_2.12@0.10.0">
       <group>io.circe</group>
@@ -70,6 +80,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
       <group>io.circe</group>
@@ -91,6 +106,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-numbers_2.12@0.10.0">
       <group>io.circe</group>
@@ -112,6 +132,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -133,6 +158,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3">
       <group>com.chuusai</group>
@@ -154,6 +184,11 @@
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/milessabin/shapeless</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
@@ -175,6 +210,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-macros_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -196,6 +236,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -217,6 +262,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/machinist_2.12@0.6.5">
       <group>org.typelevel</group>
@@ -238,6 +288,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/typelevel/machinist</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/macro-compat_2.12@1.1.1">
       <group>org.typelevel</group>
@@ -259,6 +314,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/milessabin/macro-compat</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
       <group>org.spire-math</group>
@@ -280,6 +340,11 @@
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.20">
       <group>org.scala-lang</group>
@@ -301,6 +366,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
   </components>
 </bom>

--- a/src/sbt-test/dependencies/integrationTest/etc/bom.xml
+++ b/src/sbt-test/dependencies/integrationTest/etc/bom.xml
@@ -28,6 +28,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-core_2.12@0.10.0">
       <group>io.circe</group>
@@ -49,6 +54,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-generic_2.12@0.10.0">
       <group>io.circe</group>
@@ -70,6 +80,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
       <group>io.circe</group>
@@ -91,6 +106,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-numbers_2.12@0.10.0">
       <group>io.circe</group>
@@ -112,6 +132,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -133,6 +158,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3">
       <group>com.chuusai</group>
@@ -154,6 +184,11 @@
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/milessabin/shapeless</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
@@ -175,6 +210,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-macros_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -196,6 +236,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -217,6 +262,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/machinist_2.12@0.6.5">
       <group>org.typelevel</group>
@@ -238,6 +288,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/typelevel/machinist</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/macro-compat_2.12@1.1.1">
       <group>org.typelevel</group>
@@ -259,6 +314,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/milessabin/macro-compat</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
       <group>org.spire-math</group>
@@ -280,6 +340,11 @@
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.20">
       <group>org.scala-lang</group>
@@ -301,6 +366,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
   </components>
 </bom>

--- a/src/sbt-test/dependencies/test/etc/bom.xml
+++ b/src/sbt-test/dependencies/test/etc/bom.xml
@@ -28,6 +28,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-library@2.12.20</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-core_2.12@0.10.0">
       <group>io.circe</group>
@@ -49,6 +54,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-core_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-generic_2.12@0.10.0">
       <group>io.circe</group>
@@ -70,6 +80,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-generic_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
       <group>io.circe</group>
@@ -91,6 +106,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.scalatest/scalatest_2.12@3.0.5">
       <group>org.scalatest</group>
@@ -112,6 +132,11 @@
       </licenses>
       <purl>pkg:maven/org.scalatest/scalatest_2.12@3.0.5</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.scalatest.org</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-numbers_2.12@0.10.0">
       <group>io.circe</group>
@@ -133,6 +158,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-numbers_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -154,6 +184,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3">
       <group>com.chuusai</group>
@@ -175,6 +210,11 @@
       </licenses>
       <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/milessabin/shapeless</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
@@ -196,6 +236,11 @@
       </licenses>
       <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.scalactic/scalactic_2.12@3.0.5">
       <group>org.scalactic</group>
@@ -217,6 +262,11 @@
       </licenses>
       <purl>pkg:maven/org.scalactic/scalactic_2.12@3.0.5</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.scalatest.org</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.20">
       <group>org.scala-lang</group>
@@ -238,6 +288,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.20</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.6">
       <group>org.scala-lang.modules</group>
@@ -259,6 +314,11 @@
       </licenses>
       <purl>pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.6</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-macros_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -280,6 +340,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
       <group>org.typelevel</group>
@@ -301,6 +366,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/machinist_2.12@0.6.5">
       <group>org.typelevel</group>
@@ -322,6 +392,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/machinist_2.12@0.6.5</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/typelevel/machinist</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/macro-compat_2.12@1.1.1">
       <group>org.typelevel</group>
@@ -343,6 +418,11 @@
       </licenses>
       <purl>pkg:maven/org.typelevel/macro-compat_2.12@1.1.1</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/milessabin/macro-compat</url>
+        </reference>
+      </externalReferences>
     </component>
     <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
       <group>org.spire-math</group>
@@ -364,6 +444,11 @@
       </licenses>
       <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
       <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
     </component>
   </components>
 </bom>

--- a/src/sbt-test/dependenciesJson/compile/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/compile/etc/bom.json
@@ -48,7 +48,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.20",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -88,7 +94,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-core_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -128,7 +140,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-generic_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -168,7 +186,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -208,7 +232,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-numbers_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -248,7 +278,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -288,7 +324,13 @@
         }
       ],
       "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/milessabin/shapeless"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -328,7 +370,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -368,7 +416,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -408,7 +462,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -448,7 +508,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/machinist_2.12@0.6.5",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/typelevel/machinist"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -488,7 +554,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/milessabin/macro-compat"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -528,7 +600,13 @@
         }
       ],
       "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -568,7 +646,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.20",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
     }
   ]
 }

--- a/src/sbt-test/dependenciesJson/integrationTest/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/integrationTest/etc/bom.json
@@ -48,7 +48,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.20",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -88,7 +94,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-core_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -128,7 +140,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-generic_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -168,7 +186,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -208,7 +232,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-numbers_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -248,7 +278,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -288,7 +324,13 @@
         }
       ],
       "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/milessabin/shapeless"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -328,7 +370,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -368,7 +416,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -408,7 +462,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -448,7 +508,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/machinist_2.12@0.6.5",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/typelevel/machinist"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -488,7 +554,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/milessabin/macro-compat"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -528,7 +600,13 @@
         }
       ],
       "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -568,7 +646,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.20",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
     }
   ]
 }

--- a/src/sbt-test/dependenciesJson/test/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/test/etc/bom.json
@@ -48,7 +48,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.20",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -88,7 +94,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-core_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -128,7 +140,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-generic_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -168,7 +186,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -208,7 +232,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scalatest/scalatest_2.12@3.0.5",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.scalatest.org"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -248,7 +278,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-numbers_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -288,7 +324,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -328,7 +370,13 @@
         }
       ],
       "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/milessabin/shapeless"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -368,7 +416,13 @@
         }
       ],
       "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -408,7 +462,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scalactic/scalactic_2.12@3.0.5",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.scalatest.org"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -448,7 +508,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.20",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -488,7 +554,13 @@
         }
       ],
       "purl" : "pkg:maven/org.scala-lang.modules/scala-xml_2.12@1.0.6",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.scala-lang.org/"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -528,7 +600,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -568,7 +646,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -608,7 +692,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/machinist_2.12@0.6.5",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/typelevel/machinist"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -648,7 +738,13 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/macro-compat_2.12@1.1.1",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/milessabin/macro-compat"
+        }
+      ]
     },
     {
       "type" : "library",
@@ -688,7 +784,13 @@
         }
       ],
       "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Uses the `homepage` from the sbt update report to populate a `type=website` external reference on each component. This is useful where the SBOM forms the basis of an automated list of third party dependencies, alongside the licence.