### PR TITLE
fix: publish with bomFormat extension

### DIFF
--- a/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomSbtPlugin.scala
@@ -91,7 +91,12 @@ object BomSbtPlugin extends AutoPlugin {
         .value,
       bomConfigurations := Def.taskDyn(BomSbtSettings.bomConfigurationTask((configuration ?).value)).value,
       packagedArtifacts += {
-        Artifact(artifact.value.name, "cyclonedx", "xml", "cyclonedx") -> makeBom.value
+        Artifact(
+          artifact.value.name,
+          "cyclonedx",
+          BomFormat.fromSettings(bomFormat.?.value, None, bomSchemaVersion.value).string,
+          "cyclonedx"
+        ) -> makeBom.value
       },
     )
   }


### PR DESCRIPTION
No test yet, we probably want to revisit this in the future anyway (e.g. to allow publishing both formats at the same time)