### PR TITLE
chore: test with Java 25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         scala: [2.12.21, 3.8.3]
-        java: [temurin@17, temurin@11, temurin@8]
-        exclude:
-          - java: temurin@8
-            os: macos-latest
-          - scala: 3.8.3
-            java: temurin@8
-          - scala: 3.8.3
-            java: temurin@11
+        java: [temurin@17, temurin@25]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -60,20 +53,12 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 8
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt
@@ -126,20 +111,12 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: Setup Java (temurin@8)
-        if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: 8
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         scala: [2.12.21, 3.8.4]
-        java: [temurin@17]
+        java: [temurin@17, temurin@25]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -51,6 +51,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
+
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt
@@ -101,6 +109,14 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+          cache: sbt
+
+      - name: Setup Java (temurin@25)
+        if: matrix.java == 'temurin@25'
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 25
           cache: sbt
 
       - name: Setup sbt

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the plugin dependency to the file `project/plugins.sbt` using `addSbtPlugin`
 
 `addSbtPlugin("com.github.sbt" %% "sbt-sbom" % "0.5.0")`
 
-Note that the minimum supported version of sbt is 1.6.0 (this is what the [scripted](https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html#scripted+test+framework) tests target)
+Note that the minimum supported version of sbt is 1.10.11 (this is what the [scripted](https://www.scala-sbt.org/1.x/docs/Testing-sbt-plugins.html#scripted+test+framework) tests target)
 
 ### BOM creation
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,12 +40,12 @@ lazy val root = (project in file("."))
     },
     scriptedBufferLog := false,
     scriptedSbt := (scalaBinaryVersion.value match {
-      case "2.12" => "1.6.0"
+      case "2.12" => "1.10.11"
       case _      => "2.0.0-RC11"
     }),
     scalacOptions ++= {
       scalaBinaryVersion.value match {
-        case "2.12" => Seq("-Ywarn-unused", "-release:8")
+        case "2.12" => Seq("-Ywarn-unused", "-release:17")
         case _      => Seq("-Wunused:all")
       }
     }
@@ -88,16 +88,8 @@ ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest", "windows-
 ThisBuild / githubWorkflowScalaVersions := Seq(scala212, scala3)
 
 ThisBuild / githubWorkflowJavaVersions := Seq(
-  // Java 17 first: publish job uses the head of this list when downloading staged artifacts; sbt 2 (Scala 3 axis) needs 17+.
   JavaSpec.temurin("17"),
-  JavaSpec.temurin("11"),
-  JavaSpec.temurin("8")
-)
-
-ThisBuild / githubWorkflowBuildMatrixExclusions ++= Seq(
-  MatrixExclude(Map("java" -> "temurin@8", "os" -> "macos-latest")),
-  MatrixExclude(Map("scala" -> scala3, "java" -> "temurin@8")),
-  MatrixExclude(Map("scala" -> scala3, "java" -> "temurin@11"))
+  JavaSpec.temurin("25"),
 )
 
 // Semantic DB (used by scalafix)

--- a/build.sbt
+++ b/build.sbt
@@ -40,12 +40,12 @@ lazy val root = (project in file("."))
     },
     scriptedBufferLog := false,
     scriptedSbt := (scalaBinaryVersion.value match {
-      case "2.12" => "1.6.0"
+      case "2.12" => "1.10.11"
       case _      => "2.0.0"
     }),
     scalacOptions ++= {
       scalaBinaryVersion.value match {
-        case "2.12" => Seq("-Ywarn-unused", "-release:8")
+        case "2.12" => Seq("-Ywarn-unused", "-release:17")
         case _      => Seq("-Wunused:all")
       }
     }
@@ -88,8 +88,8 @@ ThisBuild / githubWorkflowOSes := Seq("ubuntu-latest", "macos-latest", "windows-
 ThisBuild / githubWorkflowScalaVersions := Seq(scala212, scala3)
 
 ThisBuild / githubWorkflowJavaVersions := Seq(
-  // Java 17 first: publish job uses the head of this list when downloading staged artifacts; sbt 2 (Scala 3 axis) needs 17+.
-  JavaSpec.temurin("17")
+  JavaSpec.temurin("17"),
+  JavaSpec.temurin("25"),
 )
 
 // Semantic DB (used by scalafix)


### PR DESCRIPTION
Following cyclonedx-core-java doing the same
https://github.com/CycloneDX/cyclonedx-core-java/releases/tag/cyclonedx-core-java-12.0.0

This also updates the sbt version for the scripted tests to 1.9.9, since versions up to 1.8.3 don't work with Java 25. On balance it seems more valuable to test with Java 25 than to test with even older sbt versions.