### PR TITLE
Ensure component order is deterministic

### DIFF
--- a/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
@@ -93,7 +93,7 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, rootModul
         log.warn(s"bom-ref must be distinct: $bomRef")
         components.foreach(_.setBomRef(null))
     }
-    components
+    components.sortBy(c => Option(c.getBomRef).getOrElse(""))
   }
 
   private def configurationsForComponents(configuration: Configuration): Seq[sbt.Configuration] = {

--- a/src/sbt-test/dependencies/compile/etc/bom.xml
+++ b/src/sbt-test/dependencies/compile/etc/bom.xml
@@ -14,29 +14,29 @@
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-library</name>
-      <version>2.12.21</version>
+    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
+      <group>com.chuusai</group>
+      <name>shapeless_2.12</name>
+      <version>2.3.3</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
-        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
-        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
-        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
-        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
+        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
+        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
+        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
+        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
       </hashes>
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://www.scala-lang.org/</url>
+          <url>https://github.com/milessabin/shapeless</url>
         </reference>
       </externalReferences>
     </component>
@@ -92,17 +92,17 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
-      <name>circe-parser_2.12</name>
+      <name>circe-jawn_2.12</name>
       <version>0.10.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
-        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
-        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
-        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
-        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
+        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
+        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
+        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
+        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
       </hashes>
       <licenses>
         <license>
@@ -110,7 +110,7 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
-      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -144,6 +144,110 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+      <group>io.circe</group>
+      <name>circe-parser_2.12</name>
+      <version>0.10.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
+        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
+        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
+        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
+        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-library</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
+        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
+        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
+        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
+        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-reflect</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
+        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
+        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
+        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
+        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
+      <group>org.spire-math</group>
+      <name>jawn-parser_2.12</name>
+      <version>0.13.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
+        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
+        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
+        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
+        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
       <group>org.typelevel</group>
       <name>cats-core_2.12</name>
@@ -170,55 +274,29 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
-      <group>com.chuusai</group>
-      <name>shapeless_2.12</name>
-      <version>2.3.3</version>
+    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
+      <group>org.typelevel</group>
+      <name>cats-kernel_2.12</name>
+      <version>1.4.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
-        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
-        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
-        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
-        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
+        <hash alg="MD5">78d0958b2a31998e2d5f5b00f6632706</hash>
+        <hash alg="SHA-1">af8aea4585e5bd90fe071324f98c461ac7b62907</hash>
+        <hash alg="SHA-256">118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b</hash>
+        <hash alg="SHA-512">9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c</hash>
+        <hash alg="SHA-384">245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a</hash>
       </hashes>
       <licenses>
         <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
-      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
+      <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://github.com/milessabin/shapeless</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
-      <group>io.circe</group>
-      <name>circe-jawn_2.12</name>
-      <version>0.10.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
-        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
-        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
-        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
-        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/circe/circe</url>
+          <url>https://github.com/typelevel/cats</url>
         </reference>
       </externalReferences>
     </component>
@@ -241,32 +319,6 @@
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/typelevel/cats</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
-      <group>org.typelevel</group>
-      <name>cats-kernel_2.12</name>
-      <version>1.4.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">78d0958b2a31998e2d5f5b00f6632706</hash>
-        <hash alg="SHA-1">af8aea4585e5bd90fe071324f98c461ac7b62907</hash>
-        <hash alg="SHA-256">118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b</hash>
-        <hash alg="SHA-512">9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c</hash>
-        <hash alg="SHA-384">245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -323,58 +375,6 @@
       <externalReferences>
         <reference type="website">
           <url>https://github.com/milessabin/macro-compat</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
-      <group>org.spire-math</group>
-      <name>jawn-parser_2.12</name>
-      <version>0.13.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
-        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
-        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
-        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
-        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>http://github.com/non/jawn</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-reflect</name>
-      <version>2.12.21</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
-        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
-        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
-        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
-        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://www.scala-lang.org/</url>
         </reference>
       </externalReferences>
     </component>

--- a/src/sbt-test/dependencies/compileNoTree/etc/bom.xml
+++ b/src/sbt-test/dependencies/compileNoTree/etc/bom.xml
@@ -14,29 +14,29 @@
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-library</name>
-      <version>2.12.21</version>
+    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
+      <group>com.chuusai</group>
+      <name>shapeless_2.12</name>
+      <version>2.3.3</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
-        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
-        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
-        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
-        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
+        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
+        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
+        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
+        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
       </hashes>
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://www.scala-lang.org/</url>
+          <url>https://github.com/milessabin/shapeless</url>
         </reference>
       </externalReferences>
     </component>
@@ -92,17 +92,17 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
-      <name>circe-parser_2.12</name>
+      <name>circe-jawn_2.12</name>
       <version>0.10.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
-        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
-        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
-        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
-        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
+        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
+        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
+        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
+        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
       </hashes>
       <licenses>
         <license>
@@ -110,7 +110,7 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
-      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -144,6 +144,110 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+      <group>io.circe</group>
+      <name>circe-parser_2.12</name>
+      <version>0.10.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
+        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
+        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
+        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
+        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-library</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
+        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
+        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
+        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
+        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-reflect</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
+        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
+        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
+        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
+        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
+      <group>org.spire-math</group>
+      <name>jawn-parser_2.12</name>
+      <version>0.13.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
+        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
+        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
+        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
+        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
       <group>org.typelevel</group>
       <name>cats-core_2.12</name>
@@ -170,55 +274,29 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
-      <group>com.chuusai</group>
-      <name>shapeless_2.12</name>
-      <version>2.3.3</version>
+    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
+      <group>org.typelevel</group>
+      <name>cats-kernel_2.12</name>
+      <version>1.4.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
-        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
-        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
-        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
-        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
+        <hash alg="MD5">78d0958b2a31998e2d5f5b00f6632706</hash>
+        <hash alg="SHA-1">af8aea4585e5bd90fe071324f98c461ac7b62907</hash>
+        <hash alg="SHA-256">118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b</hash>
+        <hash alg="SHA-512">9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c</hash>
+        <hash alg="SHA-384">245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a</hash>
       </hashes>
       <licenses>
         <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
-      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
+      <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://github.com/milessabin/shapeless</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
-      <group>io.circe</group>
-      <name>circe-jawn_2.12</name>
-      <version>0.10.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
-        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
-        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
-        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
-        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/circe/circe</url>
+          <url>https://github.com/typelevel/cats</url>
         </reference>
       </externalReferences>
     </component>
@@ -241,32 +319,6 @@
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/typelevel/cats</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
-      <group>org.typelevel</group>
-      <name>cats-kernel_2.12</name>
-      <version>1.4.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">78d0958b2a31998e2d5f5b00f6632706</hash>
-        <hash alg="SHA-1">af8aea4585e5bd90fe071324f98c461ac7b62907</hash>
-        <hash alg="SHA-256">118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b</hash>
-        <hash alg="SHA-512">9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c</hash>
-        <hash alg="SHA-384">245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -323,58 +375,6 @@
       <externalReferences>
         <reference type="website">
           <url>https://github.com/milessabin/macro-compat</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
-      <group>org.spire-math</group>
-      <name>jawn-parser_2.12</name>
-      <version>0.13.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
-        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
-        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
-        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
-        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>http://github.com/non/jawn</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-reflect</name>
-      <version>2.12.21</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
-        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
-        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
-        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
-        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://www.scala-lang.org/</url>
         </reference>
       </externalReferences>
     </component>

--- a/src/sbt-test/dependencies/integrationTest/etc/bom.xml
+++ b/src/sbt-test/dependencies/integrationTest/etc/bom.xml
@@ -14,29 +14,29 @@
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-library</name>
-      <version>2.12.21</version>
+    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
+      <group>com.chuusai</group>
+      <name>shapeless_2.12</name>
+      <version>2.3.3</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
-        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
-        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
-        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
-        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
+        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
+        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
+        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
+        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
       </hashes>
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://www.scala-lang.org/</url>
+          <url>https://github.com/milessabin/shapeless</url>
         </reference>
       </externalReferences>
     </component>
@@ -92,17 +92,17 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
-      <name>circe-parser_2.12</name>
+      <name>circe-jawn_2.12</name>
       <version>0.10.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
-        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
-        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
-        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
-        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
+        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
+        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
+        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
+        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
       </hashes>
       <licenses>
         <license>
@@ -110,7 +110,7 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
-      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -144,6 +144,110 @@
         </reference>
       </externalReferences>
     </component>
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+      <group>io.circe</group>
+      <name>circe-parser_2.12</name>
+      <version>0.10.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
+        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
+        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
+        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
+        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/circe/circe</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-library</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
+        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
+        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
+        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
+        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-reflect</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
+        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
+        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
+        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
+        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
+      <group>org.spire-math</group>
+      <name>jawn-parser_2.12</name>
+      <version>0.13.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
+        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
+        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
+        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
+        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
+    </component>
     <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
       <group>org.typelevel</group>
       <name>cats-core_2.12</name>
@@ -170,55 +274,29 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
-      <group>com.chuusai</group>
-      <name>shapeless_2.12</name>
-      <version>2.3.3</version>
+    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
+      <group>org.typelevel</group>
+      <name>cats-kernel_2.12</name>
+      <version>1.4.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
-        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
-        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
-        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
-        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
+        <hash alg="MD5">78d0958b2a31998e2d5f5b00f6632706</hash>
+        <hash alg="SHA-1">af8aea4585e5bd90fe071324f98c461ac7b62907</hash>
+        <hash alg="SHA-256">118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b</hash>
+        <hash alg="SHA-512">9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c</hash>
+        <hash alg="SHA-384">245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a</hash>
       </hashes>
       <licenses>
         <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
-      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
+      <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://github.com/milessabin/shapeless</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
-      <group>io.circe</group>
-      <name>circe-jawn_2.12</name>
-      <version>0.10.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
-        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
-        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
-        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
-        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/circe/circe</url>
+          <url>https://github.com/typelevel/cats</url>
         </reference>
       </externalReferences>
     </component>
@@ -241,32 +319,6 @@
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/typelevel/cats</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0">
-      <group>org.typelevel</group>
-      <name>cats-kernel_2.12</name>
-      <version>1.4.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">78d0958b2a31998e2d5f5b00f6632706</hash>
-        <hash alg="SHA-1">af8aea4585e5bd90fe071324f98c461ac7b62907</hash>
-        <hash alg="SHA-256">118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b</hash>
-        <hash alg="SHA-512">9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c</hash>
-        <hash alg="SHA-384">245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -323,58 +375,6 @@
       <externalReferences>
         <reference type="website">
           <url>https://github.com/milessabin/macro-compat</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
-      <group>org.spire-math</group>
-      <name>jawn-parser_2.12</name>
-      <version>0.13.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
-        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
-        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
-        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
-        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>http://github.com/non/jawn</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-reflect</name>
-      <version>2.12.21</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
-        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
-        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
-        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
-        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://www.scala-lang.org/</url>
         </reference>
       </externalReferences>
     </component>

--- a/src/sbt-test/dependencies/test/etc/bom.xml
+++ b/src/sbt-test/dependencies/test/etc/bom.xml
@@ -14,29 +14,29 @@
     </component>
   </metadata>
   <components>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-library</name>
-      <version>2.12.21</version>
+    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
+      <group>com.chuusai</group>
+      <name>shapeless_2.12</name>
+      <version>2.3.3</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
-        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
-        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
-        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
-        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
+        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
+        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
+        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
+        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
       </hashes>
       <licenses>
         <license>
           <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
       </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
-          <url>https://www.scala-lang.org/</url>
+          <url>https://github.com/milessabin/shapeless</url>
         </reference>
       </externalReferences>
     </component>
@@ -92,17 +92,17 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
       <group>io.circe</group>
-      <name>circe-parser_2.12</name>
+      <name>circe-jawn_2.12</name>
       <version>0.10.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
-        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
-        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
-        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
-        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
+        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
+        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
+        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
+        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
+        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
       </hashes>
       <licenses>
         <license>
@@ -110,37 +110,11 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
-      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
+      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/circe/circe</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle">
-      <group>org.scalatest</group>
-      <name>scalatest_2.12</name>
-      <version>3.0.5</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">a6556b913fde52a8c4c42b527558b349</hash>
-        <hash alg="SHA-1">7bb56c0f7a3c60c465e36c6b8022a95b883d7434</hash>
-        <hash alg="SHA-256">b416b5bcef6720da469a8d8a5726e457fc2d1cd5d316e1bc283aa75a2ae005e5</hash>
-        <hash alg="SHA-512">34acff9bf76a22d4baebc52edb2d1c962869f606e4e2f006f0727dc392b19ff49fe66a129f6512b7cde7cd9a53669245c48605847ecd4dce989547a369a5d6dd</hash>
-        <hash alg="SHA-384">3fd3ec4a828a3ebb5fd0ec4aed3a9e24c80f65044e6886fe77b9d2d58f6d9771ac27a047f5b47a859d6381e7227da027</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>http://www.scalatest.org</url>
         </reference>
       </externalReferences>
     </component>
@@ -170,69 +144,17 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
-      <group>org.typelevel</group>
-      <name>cats-core_2.12</name>
-      <version>1.4.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">6d99f15cd7419e8b3cc72ffd38a5815e</hash>
-        <hash alg="SHA-1">e9be08c0a1b39f39d8a9130a856c9b184dd1ec2f</hash>
-        <hash alg="SHA-256">ab9eeca930b3e51bd063d45c1ec51097a41dd6f61d155d880f5f14be0ab14f35</hash>
-        <hash alg="SHA-512">376efe8fc921a2268c27ce56885f230aa016531f624b87cae30676b1f06965a8794699a9c5c99816b326f6ca1df2981668a4373c3da0c3b8a39cc1ed0b06a535</hash>
-        <hash alg="SHA-384">3bbcf83eeed4bf1dca3c08aa6ea9d5deb57429de844a6e385aeff4a6eb5ea1149c7616011f5cabbc692f7779e696d86d</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/typelevel/cats</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle">
-      <group>com.chuusai</group>
-      <name>shapeless_2.12</name>
-      <version>2.3.3</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">002995e4aa53f59d06e99734826cc960</hash>
-        <hash alg="SHA-1">6041e2c4871650c556a9c6842e43c04ed462b11f</hash>
-        <hash alg="SHA-256">312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033</hash>
-        <hash alg="SHA-512">58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186</hash>
-        <hash alg="SHA-384">6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://github.com/milessabin/shapeless</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/io.circe/circe-jawn_2.12@0.10.0">
+    <component type="library" bom-ref="pkg:maven/io.circe/circe-parser_2.12@0.10.0">
       <group>io.circe</group>
-      <name>circe-jawn_2.12</name>
+      <name>circe-parser_2.12</name>
       <version>0.10.0</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">3514a887a30482ecda106bfffd400b8f</hash>
-        <hash alg="SHA-1">979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9</hash>
-        <hash alg="SHA-256">8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600</hash>
-        <hash alg="SHA-512">9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599</hash>
-        <hash alg="SHA-384">45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057</hash>
+        <hash alg="MD5">aa1c3a734b5e548c2d70373d8dfbac54</hash>
+        <hash alg="SHA-1">a5508300b924dffebbb09f3350014089dd40d7ff</hash>
+        <hash alg="SHA-256">27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520</hash>
+        <hash alg="SHA-512">083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5</hash>
+        <hash alg="SHA-384">ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7</hash>
       </hashes>
       <licenses>
         <license>
@@ -240,63 +162,11 @@
           <url>http://www.apache.org/licenses/LICENSE-2.0</url>
         </license>
       </licenses>
-      <purl>pkg:maven/io.circe/circe-jawn_2.12@0.10.0</purl>
+      <purl>pkg:maven/io.circe/circe-parser_2.12@0.10.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
           <url>https://github.com/circe/circe</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle">
-      <group>org.scalactic</group>
-      <name>scalactic_2.12</name>
-      <version>3.0.5</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">db045c3a125662d76f210001158bfbbf</hash>
-        <hash alg="SHA-1">edec43902cdc7c753001501e0d8c2de78394fb03</hash>
-        <hash alg="SHA-256">57e25b4fd969b1758fe042595112c874dfea99dca5cc48eebe07ac38772a0c41</hash>
-        <hash alg="SHA-512">2b6026204793c960c6475f7e94975b0e3546db8be2c39d1bafa68f3c9460668d870cb0ab8fa85ff128ecbcb1dbdcddde922d281e7ec33d9b0ae83f7db07ee35c</hash>
-        <hash alg="SHA-384">3b2653fb93fc59fa018c87c95ba2a9db1d1c445f0f9d9de6b266fce6c618db585b95ad01019bc4342849127cdbbdabf0</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>http://www.scalatest.org</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
-      <group>org.scala-lang</group>
-      <name>scala-reflect</name>
-      <version>2.12.21</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
-        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
-        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
-        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
-        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>Apache-2.0</id>
-          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>https://www.scala-lang.org/</url>
         </reference>
       </externalReferences>
     </component>
@@ -326,17 +196,121 @@
         </reference>
       </externalReferences>
     </component>
-    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-macros_2.12@1.4.0">
-      <group>org.typelevel</group>
-      <name>cats-macros_2.12</name>
-      <version>1.4.0</version>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-library@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-library</name>
+      <version>2.12.21</version>
       <scope>required</scope>
       <hashes>
-        <hash alg="MD5">d6909c57983d748597c1d4c08d7aeae4</hash>
-        <hash alg="SHA-1">2436705a12dd4a9999c7568db4f54e4f1b95ac23</hash>
-        <hash alg="SHA-256">28d318d6265ed08f15f61af407a22bacbe6f5e139075cc06df21e6d48a7a7eb2</hash>
-        <hash alg="SHA-512">b76c63d66265c3b910bea35bac86f5b788601adbbd72eb8f6a4f9fbaa2b7f8385c859b29661853555c10076c4b3aaad6941f89ad471a718ee3ef0772078c3651</hash>
-        <hash alg="SHA-384">8315ca4c6e07a2295368c0ecd148ac5797669c7c716db7a37ed88f60cdeb0c87b638275cd49dcc3bb59cebd167df8144</hash>
+        <hash alg="MD5">8ae62906ef70e334bf35466a95da2864</hash>
+        <hash alg="SHA-1">bd2022537d062881d8335d185f9ede3d2351c9b1</hash>
+        <hash alg="SHA-256">e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c</hash>
+        <hash alg="SHA-512">69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f</hash>
+        <hash alg="SHA-384">c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-library@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scala-lang/scala-reflect@2.12.21">
+      <group>org.scala-lang</group>
+      <name>scala-reflect</name>
+      <version>2.12.21</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">b7a5571df38e6ce7467d982e48db9b46</hash>
+        <hash alg="SHA-1">03c4d800e0aa216cb323e2d8cf44cd0ceb820461</hash>
+        <hash alg="SHA-256">8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14</hash>
+        <hash alg="SHA-512">03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0</hash>
+        <hash alg="SHA-384">ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>https://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scala-lang/scala-reflect@2.12.21</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://www.scala-lang.org/</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle">
+      <group>org.scalactic</group>
+      <name>scalactic_2.12</name>
+      <version>3.0.5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">db045c3a125662d76f210001158bfbbf</hash>
+        <hash alg="SHA-1">edec43902cdc7c753001501e0d8c2de78394fb03</hash>
+        <hash alg="SHA-256">57e25b4fd969b1758fe042595112c874dfea99dca5cc48eebe07ac38772a0c41</hash>
+        <hash alg="SHA-512">2b6026204793c960c6475f7e94975b0e3546db8be2c39d1bafa68f3c9460668d870cb0ab8fa85ff128ecbcb1dbdcddde922d281e7ec33d9b0ae83f7db07ee35c</hash>
+        <hash alg="SHA-384">3b2653fb93fc59fa018c87c95ba2a9db1d1c445f0f9d9de6b266fce6c618db585b95ad01019bc4342849127cdbbdabf0</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.scalatest.org</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle">
+      <group>org.scalatest</group>
+      <name>scalatest_2.12</name>
+      <version>3.0.5</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">a6556b913fde52a8c4c42b527558b349</hash>
+        <hash alg="SHA-1">7bb56c0f7a3c60c465e36c6b8022a95b883d7434</hash>
+        <hash alg="SHA-256">b416b5bcef6720da469a8d8a5726e457fc2d1cd5d316e1bc283aa75a2ae005e5</hash>
+        <hash alg="SHA-512">34acff9bf76a22d4baebc52edb2d1c962869f606e4e2f006f0727dc392b19ff49fe66a129f6512b7cde7cd9a53669245c48605847ecd4dce989547a369a5d6dd</hash>
+        <hash alg="SHA-384">3fd3ec4a828a3ebb5fd0ec4aed3a9e24c80f65044e6886fe77b9d2d58f6d9771ac27a047f5b47a859d6381e7227da027</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>Apache-2.0</id>
+          <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://www.scalatest.org</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
+      <group>org.spire-math</group>
+      <name>jawn-parser_2.12</name>
+      <version>0.13.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
+        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
+        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
+        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
+        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
       </hashes>
       <licenses>
         <license>
@@ -344,7 +318,33 @@
           <url>http://opensource.org/licenses/MIT</url>
         </license>
       </licenses>
-      <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
+      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>http://github.com/non/jawn</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-core_2.12@1.4.0">
+      <group>org.typelevel</group>
+      <name>cats-core_2.12</name>
+      <version>1.4.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">6d99f15cd7419e8b3cc72ffd38a5815e</hash>
+        <hash alg="SHA-1">e9be08c0a1b39f39d8a9130a856c9b184dd1ec2f</hash>
+        <hash alg="SHA-256">ab9eeca930b3e51bd063d45c1ec51097a41dd6f61d155d880f5f14be0ab14f35</hash>
+        <hash alg="SHA-512">376efe8fc921a2268c27ce56885f230aa016531f624b87cae30676b1f06965a8794699a9c5c99816b326f6ca1df2981668a4373c3da0c3b8a39cc1ed0b06a535</hash>
+        <hash alg="SHA-384">3bbcf83eeed4bf1dca3c08aa6ea9d5deb57429de844a6e385aeff4a6eb5ea1149c7616011f5cabbc692f7779e696d86d</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.typelevel/cats-core_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -371,6 +371,32 @@
         </license>
       </licenses>
       <purl>pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0</purl>
+      <modified>false</modified>
+      <externalReferences>
+        <reference type="website">
+          <url>https://github.com/typelevel/cats</url>
+        </reference>
+      </externalReferences>
+    </component>
+    <component type="library" bom-ref="pkg:maven/org.typelevel/cats-macros_2.12@1.4.0">
+      <group>org.typelevel</group>
+      <name>cats-macros_2.12</name>
+      <version>1.4.0</version>
+      <scope>required</scope>
+      <hashes>
+        <hash alg="MD5">d6909c57983d748597c1d4c08d7aeae4</hash>
+        <hash alg="SHA-1">2436705a12dd4a9999c7568db4f54e4f1b95ac23</hash>
+        <hash alg="SHA-256">28d318d6265ed08f15f61af407a22bacbe6f5e139075cc06df21e6d48a7a7eb2</hash>
+        <hash alg="SHA-512">b76c63d66265c3b910bea35bac86f5b788601adbbd72eb8f6a4f9fbaa2b7f8385c859b29661853555c10076c4b3aaad6941f89ad471a718ee3ef0772078c3651</hash>
+        <hash alg="SHA-384">8315ca4c6e07a2295368c0ecd148ac5797669c7c716db7a37ed88f60cdeb0c87b638275cd49dcc3bb59cebd167df8144</hash>
+      </hashes>
+      <licenses>
+        <license>
+          <id>MIT</id>
+          <url>http://opensource.org/licenses/MIT</url>
+        </license>
+      </licenses>
+      <purl>pkg:maven/org.typelevel/cats-macros_2.12@1.4.0</purl>
       <modified>false</modified>
       <externalReferences>
         <reference type="website">
@@ -427,32 +453,6 @@
       <externalReferences>
         <reference type="website">
           <url>https://github.com/milessabin/macro-compat</url>
-        </reference>
-      </externalReferences>
-    </component>
-    <component type="library" bom-ref="pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0">
-      <group>org.spire-math</group>
-      <name>jawn-parser_2.12</name>
-      <version>0.13.0</version>
-      <scope>required</scope>
-      <hashes>
-        <hash alg="MD5">85a145b9224a5eb625a795536609ca37</hash>
-        <hash alg="SHA-1">4a2e53bbe3c6f467384327abc9bab25d7cdcada4</hash>
-        <hash alg="SHA-256">4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53</hash>
-        <hash alg="SHA-512">49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa</hash>
-        <hash alg="SHA-384">cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8</hash>
-      </hashes>
-      <licenses>
-        <license>
-          <id>MIT</id>
-          <url>http://opensource.org/licenses/MIT</url>
-        </license>
-      </licenses>
-      <purl>pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0</purl>
-      <modified>false</modified>
-      <externalReferences>
-        <reference type="website">
-          <url>http://github.com/non/jawn</url>
         </reference>
       </externalReferences>
     </component>

--- a/src/sbt-test/dependenciesJson/compile/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/compile/etc/bom.json
@@ -20,47 +20,47 @@
   "components" : [
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-library",
-      "version" : "2.12.21",
+      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "group" : "com.chuusai",
+      "name" : "shapeless_2.12",
+      "version" : "2.3.3",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "8ae62906ef70e334bf35466a95da2864"
+          "content" : "002995e4aa53f59d06e99734826cc960"
         },
         {
           "alg" : "SHA-1",
-          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
         },
         {
           "alg" : "SHA-256",
-          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
         },
         {
           "alg" : "SHA-512",
-          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
         },
         {
           "alg" : "SHA-384",
-          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
         }
       ],
       "licenses" : [
         {
           "license" : {
             "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
           }
         }
       ],
-      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://www.scala-lang.org/"
+          "url" : "https://github.com/milessabin/shapeless"
         }
       ]
     },
@@ -158,31 +158,31 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "group" : "io.circe",
-      "name" : "circe-parser_2.12",
+      "name" : "circe-jawn_2.12",
       "version" : "0.10.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+          "content" : "3514a887a30482ecda106bfffd400b8f"
         },
         {
           "alg" : "SHA-1",
-          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
         },
         {
           "alg" : "SHA-256",
-          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
         },
         {
           "alg" : "SHA-512",
-          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
         },
         {
           "alg" : "SHA-384",
-          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
         }
       ],
       "licenses" : [
@@ -193,7 +193,7 @@
           }
         }
       ],
-      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -250,6 +250,190 @@
     },
     {
       "type" : "library",
+      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "group" : "io.circe",
+      "name" : "circe-parser_2.12",
+      "version" : "0.10.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8ae62906ef70e334bf35466a95da2864"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b7a5571df38e6ce7467d982e48db9b46"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "group" : "org.spire-math",
+      "name" : "jawn-parser_2.12",
+      "version" : "0.13.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "85a145b9224a5eb625a795536609ca37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
+    },
+    {
+      "type" : "library",
       "bom-ref" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
       "group" : "org.typelevel",
       "name" : "cats-core_2.12",
@@ -296,93 +480,47 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
-      "group" : "com.chuusai",
-      "name" : "shapeless_2.12",
-      "version" : "2.3.3",
+      "bom-ref" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
+      "group" : "org.typelevel",
+      "name" : "cats-kernel_2.12",
+      "version" : "1.4.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "002995e4aa53f59d06e99734826cc960"
+          "content" : "78d0958b2a31998e2d5f5b00f6632706"
         },
         {
           "alg" : "SHA-1",
-          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
+          "content" : "af8aea4585e5bd90fe071324f98c461ac7b62907"
         },
         {
           "alg" : "SHA-256",
-          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
+          "content" : "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
         },
         {
           "alg" : "SHA-512",
-          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
+          "content" : "9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c"
         },
         {
           "alg" : "SHA-384",
-          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
+          "content" : "245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a"
         }
       ],
       "licenses" : [
         {
           "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
           }
         }
       ],
-      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://github.com/milessabin/shapeless"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "group" : "io.circe",
-      "name" : "circe-jawn_2.12",
-      "version" : "0.10.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "3514a887a30482ecda106bfffd400b8f"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/circe/circe"
+          "url" : "https://github.com/typelevel/cats"
         }
       ]
     },
@@ -424,52 +562,6 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/typelevel/cats"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
-      "group" : "org.typelevel",
-      "name" : "cats-kernel_2.12",
-      "version" : "1.4.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "78d0958b2a31998e2d5f5b00f6632706"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "af8aea4585e5bd90fe071324f98c461ac7b62907"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -567,98 +659,6 @@
         {
           "type" : "website",
           "url" : "https://github.com/milessabin/macro-compat"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "group" : "org.spire-math",
-      "name" : "jawn-parser_2.12",
-      "version" : "0.13.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "85a145b9224a5eb625a795536609ca37"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://github.com/non/jawn"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-reflect",
-      "version" : "2.12.21",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "b7a5571df38e6ce7467d982e48db9b46"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://www.scala-lang.org/"
         }
       ]
     }

--- a/src/sbt-test/dependenciesJson/compileNoTree/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/compileNoTree/etc/bom.json
@@ -20,47 +20,47 @@
   "components" : [
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-library",
-      "version" : "2.12.21",
+      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "group" : "com.chuusai",
+      "name" : "shapeless_2.12",
+      "version" : "2.3.3",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "8ae62906ef70e334bf35466a95da2864"
+          "content" : "002995e4aa53f59d06e99734826cc960"
         },
         {
           "alg" : "SHA-1",
-          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
         },
         {
           "alg" : "SHA-256",
-          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
         },
         {
           "alg" : "SHA-512",
-          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
         },
         {
           "alg" : "SHA-384",
-          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
         }
       ],
       "licenses" : [
         {
           "license" : {
             "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
           }
         }
       ],
-      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://www.scala-lang.org/"
+          "url" : "https://github.com/milessabin/shapeless"
         }
       ]
     },
@@ -158,31 +158,31 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "group" : "io.circe",
-      "name" : "circe-parser_2.12",
+      "name" : "circe-jawn_2.12",
       "version" : "0.10.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+          "content" : "3514a887a30482ecda106bfffd400b8f"
         },
         {
           "alg" : "SHA-1",
-          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
         },
         {
           "alg" : "SHA-256",
-          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
         },
         {
           "alg" : "SHA-512",
-          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
         },
         {
           "alg" : "SHA-384",
-          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
         }
       ],
       "licenses" : [
@@ -193,7 +193,7 @@
           }
         }
       ],
-      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -250,6 +250,190 @@
     },
     {
       "type" : "library",
+      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "group" : "io.circe",
+      "name" : "circe-parser_2.12",
+      "version" : "0.10.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8ae62906ef70e334bf35466a95da2864"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b7a5571df38e6ce7467d982e48db9b46"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "group" : "org.spire-math",
+      "name" : "jawn-parser_2.12",
+      "version" : "0.13.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "85a145b9224a5eb625a795536609ca37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
+    },
+    {
+      "type" : "library",
       "bom-ref" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
       "group" : "org.typelevel",
       "name" : "cats-core_2.12",
@@ -296,93 +480,47 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
-      "group" : "com.chuusai",
-      "name" : "shapeless_2.12",
-      "version" : "2.3.3",
+      "bom-ref" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
+      "group" : "org.typelevel",
+      "name" : "cats-kernel_2.12",
+      "version" : "1.4.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "002995e4aa53f59d06e99734826cc960"
+          "content" : "78d0958b2a31998e2d5f5b00f6632706"
         },
         {
           "alg" : "SHA-1",
-          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
+          "content" : "af8aea4585e5bd90fe071324f98c461ac7b62907"
         },
         {
           "alg" : "SHA-256",
-          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
+          "content" : "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
         },
         {
           "alg" : "SHA-512",
-          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
+          "content" : "9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c"
         },
         {
           "alg" : "SHA-384",
-          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
+          "content" : "245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a"
         }
       ],
       "licenses" : [
         {
           "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
           }
         }
       ],
-      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://github.com/milessabin/shapeless"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "group" : "io.circe",
-      "name" : "circe-jawn_2.12",
-      "version" : "0.10.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "3514a887a30482ecda106bfffd400b8f"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/circe/circe"
+          "url" : "https://github.com/typelevel/cats"
         }
       ]
     },
@@ -424,52 +562,6 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/typelevel/cats"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
-      "group" : "org.typelevel",
-      "name" : "cats-kernel_2.12",
-      "version" : "1.4.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "78d0958b2a31998e2d5f5b00f6632706"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "af8aea4585e5bd90fe071324f98c461ac7b62907"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -567,98 +659,6 @@
         {
           "type" : "website",
           "url" : "https://github.com/milessabin/macro-compat"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "group" : "org.spire-math",
-      "name" : "jawn-parser_2.12",
-      "version" : "0.13.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "85a145b9224a5eb625a795536609ca37"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://github.com/non/jawn"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-reflect",
-      "version" : "2.12.21",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "b7a5571df38e6ce7467d982e48db9b46"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://www.scala-lang.org/"
         }
       ]
     }

--- a/src/sbt-test/dependenciesJson/integrationTest/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/integrationTest/etc/bom.json
@@ -20,47 +20,47 @@
   "components" : [
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-library",
-      "version" : "2.12.21",
+      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "group" : "com.chuusai",
+      "name" : "shapeless_2.12",
+      "version" : "2.3.3",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "8ae62906ef70e334bf35466a95da2864"
+          "content" : "002995e4aa53f59d06e99734826cc960"
         },
         {
           "alg" : "SHA-1",
-          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
         },
         {
           "alg" : "SHA-256",
-          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
         },
         {
           "alg" : "SHA-512",
-          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
         },
         {
           "alg" : "SHA-384",
-          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
         }
       ],
       "licenses" : [
         {
           "license" : {
             "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
           }
         }
       ],
-      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://www.scala-lang.org/"
+          "url" : "https://github.com/milessabin/shapeless"
         }
       ]
     },
@@ -158,31 +158,31 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "group" : "io.circe",
-      "name" : "circe-parser_2.12",
+      "name" : "circe-jawn_2.12",
       "version" : "0.10.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+          "content" : "3514a887a30482ecda106bfffd400b8f"
         },
         {
           "alg" : "SHA-1",
-          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
         },
         {
           "alg" : "SHA-256",
-          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
         },
         {
           "alg" : "SHA-512",
-          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
         },
         {
           "alg" : "SHA-384",
-          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
         }
       ],
       "licenses" : [
@@ -193,7 +193,7 @@
           }
         }
       ],
-      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -250,6 +250,190 @@
     },
     {
       "type" : "library",
+      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "group" : "io.circe",
+      "name" : "circe-parser_2.12",
+      "version" : "0.10.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/circe/circe"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "8ae62906ef70e334bf35466a95da2864"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b7a5571df38e6ce7467d982e48db9b46"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "group" : "org.spire-math",
+      "name" : "jawn-parser_2.12",
+      "version" : "0.13.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "85a145b9224a5eb625a795536609ca37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
+    },
+    {
+      "type" : "library",
       "bom-ref" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
       "group" : "org.typelevel",
       "name" : "cats-core_2.12",
@@ -296,93 +480,47 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
-      "group" : "com.chuusai",
-      "name" : "shapeless_2.12",
-      "version" : "2.3.3",
+      "bom-ref" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
+      "group" : "org.typelevel",
+      "name" : "cats-kernel_2.12",
+      "version" : "1.4.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "002995e4aa53f59d06e99734826cc960"
+          "content" : "78d0958b2a31998e2d5f5b00f6632706"
         },
         {
           "alg" : "SHA-1",
-          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
+          "content" : "af8aea4585e5bd90fe071324f98c461ac7b62907"
         },
         {
           "alg" : "SHA-256",
-          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
+          "content" : "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
         },
         {
           "alg" : "SHA-512",
-          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
+          "content" : "9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c"
         },
         {
           "alg" : "SHA-384",
-          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
+          "content" : "245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a"
         }
       ],
       "licenses" : [
         {
           "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
           }
         }
       ],
-      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://github.com/milessabin/shapeless"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "group" : "io.circe",
-      "name" : "circe-jawn_2.12",
-      "version" : "0.10.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "3514a887a30482ecda106bfffd400b8f"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/circe/circe"
+          "url" : "https://github.com/typelevel/cats"
         }
       ]
     },
@@ -424,52 +562,6 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/typelevel/cats"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
-      "group" : "org.typelevel",
-      "name" : "cats-kernel_2.12",
-      "version" : "1.4.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "78d0958b2a31998e2d5f5b00f6632706"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "af8aea4585e5bd90fe071324f98c461ac7b62907"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "118074e737f810edd004588f0c681efb7d0d216ae9c481e3c952a07e47d3578b"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "9e34a66d68f5d4a5f35922162b29c0ba48b9769d47e858cb65aea885574c3757ebeeb7eeceb992a703e6ed1d247e53251899010a9738b389d5baf59077fbac2c"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "245d6916298e3ad164dd0ad61cc49e64caacb7d35c633706ca9e25c3eece2dd6abb2a425f97bcbdd3fa9da106e0fb44a"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -567,98 +659,6 @@
         {
           "type" : "website",
           "url" : "https://github.com/milessabin/macro-compat"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "group" : "org.spire-math",
-      "name" : "jawn-parser_2.12",
-      "version" : "0.13.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "85a145b9224a5eb625a795536609ca37"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://github.com/non/jawn"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-reflect",
-      "version" : "2.12.21",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "b7a5571df38e6ce7467d982e48db9b46"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://www.scala-lang.org/"
         }
       ]
     }

--- a/src/sbt-test/dependenciesJson/test/etc/bom.json
+++ b/src/sbt-test/dependenciesJson/test/etc/bom.json
@@ -20,47 +20,47 @@
   "components" : [
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-library",
-      "version" : "2.12.21",
+      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
+      "group" : "com.chuusai",
+      "name" : "shapeless_2.12",
+      "version" : "2.3.3",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "8ae62906ef70e334bf35466a95da2864"
+          "content" : "002995e4aa53f59d06e99734826cc960"
         },
         {
           "alg" : "SHA-1",
-          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
+          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
         },
         {
           "alg" : "SHA-256",
-          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
+          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
         },
         {
           "alg" : "SHA-512",
-          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
+          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
         },
         {
           "alg" : "SHA-384",
-          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
         }
       ],
       "licenses" : [
         {
           "license" : {
             "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
           }
         }
       ],
-      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
-          "url" : "https://www.scala-lang.org/"
+          "url" : "https://github.com/milessabin/shapeless"
         }
       ]
     },
@@ -158,31 +158,31 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "group" : "io.circe",
-      "name" : "circe-parser_2.12",
+      "name" : "circe-jawn_2.12",
       "version" : "0.10.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
+          "content" : "3514a887a30482ecda106bfffd400b8f"
         },
         {
           "alg" : "SHA-1",
-          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
+          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
         },
         {
           "alg" : "SHA-256",
-          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
+          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
         },
         {
           "alg" : "SHA-512",
-          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
+          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
         },
         {
           "alg" : "SHA-384",
-          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
+          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
         }
       ],
       "licenses" : [
@@ -193,58 +193,12 @@
           }
         }
       ],
-      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
+      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
           "url" : "https://github.com/circe/circe"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle",
-      "group" : "org.scalatest",
-      "name" : "scalatest_2.12",
-      "version" : "3.0.5",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "a6556b913fde52a8c4c42b527558b349"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "7bb56c0f7a3c60c465e36c6b8022a95b883d7434"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "b416b5bcef6720da469a8d8a5726e457fc2d1cd5d316e1bc283aa75a2ae005e5"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "34acff9bf76a22d4baebc52edb2d1c962869f606e4e2f006f0727dc392b19ff49fe66a129f6512b7cde7cd9a53669245c48605847ecd4dce989547a369a5d6dd"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "3fd3ec4a828a3ebb5fd0ec4aed3a9e24c80f65044e6886fe77b9d2d58f6d9771ac27a047f5b47a859d6381e7227da027"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://www.scalatest.org"
         }
       ]
     },
@@ -296,123 +250,31 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
-      "group" : "org.typelevel",
-      "name" : "cats-core_2.12",
-      "version" : "1.4.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "6d99f15cd7419e8b3cc72ffd38a5815e"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "e9be08c0a1b39f39d8a9130a856c9b184dd1ec2f"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "ab9eeca930b3e51bd063d45c1ec51097a41dd6f61d155d880f5f14be0ab14f35"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "376efe8fc921a2268c27ce56885f230aa016531f624b87cae30676b1f06965a8794699a9c5c99816b326f6ca1df2981668a4373c3da0c3b8a39cc1ed0b06a535"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "3bbcf83eeed4bf1dca3c08aa6ea9d5deb57429de844a6e385aeff4a6eb5ea1149c7616011f5cabbc692f7779e696d86d"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/typelevel/cats"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
-      "group" : "com.chuusai",
-      "name" : "shapeless_2.12",
-      "version" : "2.3.3",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "002995e4aa53f59d06e99734826cc960"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "6041e2c4871650c556a9c6842e43c04ed462b11f"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "312e301432375132ab49592bd8d22b9cd42a338a6300c6157fb4eafd1e3d5033"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "58043efb20dd5490d07b188b2876509b521e77fc77b4c3ea2f9f88bc03030620dbea5a28ea4c769fde8593165eb210df1194b0f3845cbcdf78683ab553dbe186"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "6e0536bbbec29990b9de1f6fcf5526cb694596bb22603dd4c6d95a2c92bc3c27891af223a3a0d4a1e3dea96188bdd4be"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0.txt"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/com.chuusai/shapeless_2.12@2.3.3?type=bundle",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://github.com/milessabin/shapeless"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
+      "bom-ref" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
       "group" : "io.circe",
-      "name" : "circe-jawn_2.12",
+      "name" : "circe-parser_2.12",
       "version" : "0.10.0",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "3514a887a30482ecda106bfffd400b8f"
+          "content" : "aa1c3a734b5e548c2d70373d8dfbac54"
         },
         {
           "alg" : "SHA-1",
-          "content" : "979ce1dc1d26ae0bf33601e0bb4d3a49dba549d9"
+          "content" : "a5508300b924dffebbb09f3350014089dd40d7ff"
         },
         {
           "alg" : "SHA-256",
-          "content" : "8ebc3204f91e25b28fa8fb0ae17c58c2826f3fb4c3cb0a6f10d3c95760ecb600"
+          "content" : "27c58a6bee47df9eeda409373870283c42a9321a5c7859f6ec49dadc802aa520"
         },
         {
           "alg" : "SHA-512",
-          "content" : "9d6cdd7e0ff044537567ad0dc4d349dd545cfeda7d4aea0febbb3ed61e460f3ce79f89c87c9b7f93f09b49a5a1ced1bd0fad25a1b9704dac037b0017c9217599"
+          "content" : "083fa871ae2b3da51554f8915c77c3792c4b836f92d1ede5cb6bdcdc074f29739f4ea20fd27a4eb2659e69f7f837b80e5f5e87652533cc516719778593d750a5"
         },
         {
           "alg" : "SHA-384",
-          "content" : "45d8a33e61952899e78dd41c304a30fd6b3175c2f6d0843b33ea6ccd61d5768d4a09aa10010a2b868eccf1ed2e6e9057"
+          "content" : "ce01c27ace5772de1a42bd0c7375465110501cf409e8467e8a5cb3b0be56b34cca6dd682379725abd5887351535ea0d7"
         }
       ],
       "licenses" : [
@@ -423,104 +285,12 @@
           }
         }
       ],
-      "purl" : "pkg:maven/io.circe/circe-jawn_2.12@0.10.0",
+      "purl" : "pkg:maven/io.circe/circe-parser_2.12@0.10.0",
       "modified" : false,
       "externalReferences" : [
         {
           "type" : "website",
           "url" : "https://github.com/circe/circe"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle",
-      "group" : "org.scalactic",
-      "name" : "scalactic_2.12",
-      "version" : "3.0.5",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "db045c3a125662d76f210001158bfbbf"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "edec43902cdc7c753001501e0d8c2de78394fb03"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "57e25b4fd969b1758fe042595112c874dfea99dca5cc48eebe07ac38772a0c41"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "2b6026204793c960c6475f7e94975b0e3546db8be2c39d1bafa68f3c9460668d870cb0ab8fa85ff128ecbcb1dbdcddde922d281e7ec33d9b0ae83f7db07ee35c"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "3b2653fb93fc59fa018c87c95ba2a9db1d1c445f0f9d9de6b266fce6c618db585b95ad01019bc4342849127cdbbdabf0"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://www.scalatest.org"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "group" : "org.scala-lang",
-      "name" : "scala-reflect",
-      "version" : "2.12.21",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "b7a5571df38e6ce7467d982e48db9b46"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "Apache-2.0",
-            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "https://www.scala-lang.org/"
         }
       ]
     },
@@ -572,31 +342,215 @@
     },
     {
       "type" : "library",
-      "bom-ref" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
-      "group" : "org.typelevel",
-      "name" : "cats-macros_2.12",
-      "version" : "1.4.0",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-library",
+      "version" : "2.12.21",
       "scope" : "required",
       "hashes" : [
         {
           "alg" : "MD5",
-          "content" : "d6909c57983d748597c1d4c08d7aeae4"
+          "content" : "8ae62906ef70e334bf35466a95da2864"
         },
         {
           "alg" : "SHA-1",
-          "content" : "2436705a12dd4a9999c7568db4f54e4f1b95ac23"
+          "content" : "bd2022537d062881d8335d185f9ede3d2351c9b1"
         },
         {
           "alg" : "SHA-256",
-          "content" : "28d318d6265ed08f15f61af407a22bacbe6f5e139075cc06df21e6d48a7a7eb2"
+          "content" : "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c"
         },
         {
           "alg" : "SHA-512",
-          "content" : "b76c63d66265c3b910bea35bac86f5b788601adbbd72eb8f6a4f9fbaa2b7f8385c859b29661853555c10076c4b3aaad6941f89ad471a718ee3ef0772078c3651"
+          "content" : "69236b9b056b87077e8608225f041ebef6c2622de5cdd8733555693befe994b9b85e91042960ae6cb6c7ef2818ab2de83a95a3e0fa414a699cf2ff3927d6558f"
         },
         {
           "alg" : "SHA-384",
-          "content" : "8315ca4c6e07a2295368c0ecd148ac5797669c7c716db7a37ed88f60cdeb0c87b638275cd49dcc3bb59cebd167df8144"
+          "content" : "c3419a097cee20e3bf281ed5e20ddc71c08475598eb483bdf17b512c75a5299e17e2606afd178ea53f3d3edc8d621be8"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-library@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "group" : "org.scala-lang",
+      "name" : "scala-reflect",
+      "version" : "2.12.21",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "b7a5571df38e6ce7467d982e48db9b46"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "03c4d800e0aa216cb323e2d8cf44cd0ceb820461"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "03214b9ed9d09966c0fd6df30b613a549075a2e2c2b43eef655539456226aa432d790c9050ac78c1e6a026bd85a98ac1a2f1997b0885faa3e39fab1db2b6a8c0"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "ab369473d12ac219a6c4f2d3ffbee91de4c8cbaa0e90432d43cfc30337b91499ec12ac79398348cb4467bc0d6ddd190e"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scala-lang/scala-reflect@2.12.21",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://www.scala-lang.org/"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle",
+      "group" : "org.scalactic",
+      "name" : "scalactic_2.12",
+      "version" : "3.0.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "db045c3a125662d76f210001158bfbbf"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "edec43902cdc7c753001501e0d8c2de78394fb03"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "57e25b4fd969b1758fe042595112c874dfea99dca5cc48eebe07ac38772a0c41"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "2b6026204793c960c6475f7e94975b0e3546db8be2c39d1bafa68f3c9460668d870cb0ab8fa85ff128ecbcb1dbdcddde922d281e7ec33d9b0ae83f7db07ee35c"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3b2653fb93fc59fa018c87c95ba2a9db1d1c445f0f9d9de6b266fce6c618db585b95ad01019bc4342849127cdbbdabf0"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scalactic/scalactic_2.12@3.0.5?type=bundle",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.scalatest.org"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle",
+      "group" : "org.scalatest",
+      "name" : "scalatest_2.12",
+      "version" : "3.0.5",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "a6556b913fde52a8c4c42b527558b349"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "7bb56c0f7a3c60c465e36c6b8022a95b883d7434"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "b416b5bcef6720da469a8d8a5726e457fc2d1cd5d316e1bc283aa75a2ae005e5"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "34acff9bf76a22d4baebc52edb2d1c962869f606e4e2f006f0727dc392b19ff49fe66a129f6512b7cde7cd9a53669245c48605847ecd4dce989547a369a5d6dd"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3fd3ec4a828a3ebb5fd0ec4aed3a9e24c80f65044e6886fe77b9d2d58f6d9771ac27a047f5b47a859d6381e7227da027"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "Apache-2.0",
+            "url" : "http://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.scalatest/scalatest_2.12@3.0.5?type=bundle",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://www.scalatest.org"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "group" : "org.spire-math",
+      "name" : "jawn-parser_2.12",
+      "version" : "0.13.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "85a145b9224a5eb625a795536609ca37"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
         }
       ],
       "licenses" : [
@@ -607,7 +561,53 @@
           }
         }
       ],
-      "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
+      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "http://github.com/non/jawn"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
+      "group" : "org.typelevel",
+      "name" : "cats-core_2.12",
+      "version" : "1.4.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "6d99f15cd7419e8b3cc72ffd38a5815e"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "e9be08c0a1b39f39d8a9130a856c9b184dd1ec2f"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "ab9eeca930b3e51bd063d45c1ec51097a41dd6f61d155d880f5f14be0ab14f35"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "376efe8fc921a2268c27ce56885f230aa016531f624b87cae30676b1f06965a8794699a9c5c99816b326f6ca1df2981668a4373c3da0c3b8a39cc1ed0b06a535"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "3bbcf83eeed4bf1dca3c08aa6ea9d5deb57429de844a6e385aeff4a6eb5ea1149c7616011f5cabbc692f7779e696d86d"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.typelevel/cats-core_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -654,6 +654,52 @@
         }
       ],
       "purl" : "pkg:maven/org.typelevel/cats-kernel_2.12@1.4.0",
+      "modified" : false,
+      "externalReferences" : [
+        {
+          "type" : "website",
+          "url" : "https://github.com/typelevel/cats"
+        }
+      ]
+    },
+    {
+      "type" : "library",
+      "bom-ref" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
+      "group" : "org.typelevel",
+      "name" : "cats-macros_2.12",
+      "version" : "1.4.0",
+      "scope" : "required",
+      "hashes" : [
+        {
+          "alg" : "MD5",
+          "content" : "d6909c57983d748597c1d4c08d7aeae4"
+        },
+        {
+          "alg" : "SHA-1",
+          "content" : "2436705a12dd4a9999c7568db4f54e4f1b95ac23"
+        },
+        {
+          "alg" : "SHA-256",
+          "content" : "28d318d6265ed08f15f61af407a22bacbe6f5e139075cc06df21e6d48a7a7eb2"
+        },
+        {
+          "alg" : "SHA-512",
+          "content" : "b76c63d66265c3b910bea35bac86f5b788601adbbd72eb8f6a4f9fbaa2b7f8385c859b29661853555c10076c4b3aaad6941f89ad471a718ee3ef0772078c3651"
+        },
+        {
+          "alg" : "SHA-384",
+          "content" : "8315ca4c6e07a2295368c0ecd148ac5797669c7c716db7a37ed88f60cdeb0c87b638275cd49dcc3bb59cebd167df8144"
+        }
+      ],
+      "licenses" : [
+        {
+          "license" : {
+            "id" : "MIT",
+            "url" : "http://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl" : "pkg:maven/org.typelevel/cats-macros_2.12@1.4.0",
       "modified" : false,
       "externalReferences" : [
         {
@@ -751,52 +797,6 @@
         {
           "type" : "website",
           "url" : "https://github.com/milessabin/macro-compat"
-        }
-      ]
-    },
-    {
-      "type" : "library",
-      "bom-ref" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "group" : "org.spire-math",
-      "name" : "jawn-parser_2.12",
-      "version" : "0.13.0",
-      "scope" : "required",
-      "hashes" : [
-        {
-          "alg" : "MD5",
-          "content" : "85a145b9224a5eb625a795536609ca37"
-        },
-        {
-          "alg" : "SHA-1",
-          "content" : "4a2e53bbe3c6f467384327abc9bab25d7cdcada4"
-        },
-        {
-          "alg" : "SHA-256",
-          "content" : "4aa94d58b2b36f1df8270e1dbfc46b07cc4d9850a963b6f82d9c654a71f5ec53"
-        },
-        {
-          "alg" : "SHA-512",
-          "content" : "49cac3420253f280b6dccc70cd2805c6b14bd43a862392a6766cf6412948ebde4add69e1876efb3335f18f1b24c9064323b17d87c6abb6a41edd7e9b2b3e01fa"
-        },
-        {
-          "alg" : "SHA-384",
-          "content" : "cee97b1aff168ea812eba4a1f136a2fdd27258bf53177c566489fbd88d8167ce92f84d0872ee84ce8d24291089a6e4a8"
-        }
-      ],
-      "licenses" : [
-        {
-          "license" : {
-            "id" : "MIT",
-            "url" : "http://opensource.org/licenses/MIT"
-          }
-        }
-      ],
-      "purl" : "pkg:maven/org.spire-math/jawn-parser_2.12@0.13.0",
-      "modified" : false,
-      "externalReferences" : [
-        {
-          "type" : "website",
-          "url" : "http://github.com/non/jawn"
         }
       ]
     }


### PR DESCRIPTION
In some cases, the order of components written to SBOM files changes, making it difficult to verify the correctness of generated SBOMs and resulting in unnecessary diffs. To fix this, components are now sorted by their bom-ref property before being written.

This does mean it is likely that BOMs will have significant ordering changes, as reflected by the updated tests, but it should be a one time change to the new deterministic ordering.