### PR TITLE
Exclude disconnected project dependencies from SBOMs

### DIFF
--- a/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
+++ b/src/main/scala/com/github/sbt/sbom/BomExtractor.scala
@@ -26,7 +26,7 @@ import sbt.librarymanagement.ModuleReport
 import java.util.{ TreeMap as TM, UUID }
 import scala.collection.JavaConverters.*
 
-import SbtUpdateReport.{ ModuleGraph, getModuleQualifier }
+import SbtUpdateReport.{ GraphModuleId, ModuleGraph, getModuleQualifier }
 
 class BomExtractor(settings: BomExtractorParams, report: UpdateReport, rootModuleID: ModuleID, log: Logger) {
   private val serialNumber: String = "urn:uuid:" + UUID.randomUUID.toString
@@ -120,12 +120,15 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, rootModul
     report
       .configuration(configuration)
       .map { configurationReport =>
+        val reachableModuleIds = moduleGraph(configurationReport).reachableModuleIdsFrom(GraphModuleId(rootModuleID))
         log.info(
           s"Configuration name = ${configurationReport.configuration.name}, modules: ${configurationReport.modules.size}"
         )
-        configurationReport.modules.map { module =>
-          new ComponentExtractor(module).component
-        }
+        configurationReport.modules
+          .filter(module => reachableModuleIds(GraphModuleId(module.module)))
+          .map { module =>
+            new ComponentExtractor(module).component
+          }
       }
       .getOrElse(Seq())
   }
@@ -253,8 +256,9 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, rootModul
 
   class DependencyTreeExtractor(configurationReport: ConfigurationReport) {
     def dependencyTree: Seq[Dependency] = {
+      val reachableModuleIds = moduleGraph.reachableModuleIdsFrom(GraphModuleId(rootModuleID))
       moduleGraph.nodes
-        .filter(_.evictedByVersion.isEmpty)
+        .filter(module => reachableModuleIds(module.id) && module.evictedByVersion.isEmpty)
         .sortBy(_.id.idString)
         .map { node =>
           val bomRef = purl(node.id.organization, node.id.name, node.id.version, node.qualifier)
@@ -274,9 +278,12 @@ class BomExtractor(settings: BomExtractorParams, report: UpdateReport, rootModul
         }
     }
 
-    private def moduleGraph: ModuleGraph =
-      SbtUpdateReport.fromConfigurationReport(configurationReport, rootModuleID, log)
+    private lazy val moduleGraph: ModuleGraph =
+      BomExtractor.this.moduleGraph(configurationReport)
   }
+
+  private def moduleGraph(configurationReport: ConfigurationReport): ModuleGraph =
+    SbtUpdateReport.fromConfigurationReport(configurationReport, rootModuleID, log)
 
   private def toCycloneDxProjectType(e: ProjectType): Component.Type = {
     e match {

--- a/src/main/scala/com/github/sbt/sbom/SbtUpdateReport.scala
+++ b/src/main/scala/com/github/sbt/sbom/SbtUpdateReport.scala
@@ -40,6 +40,20 @@ object SbtUpdateReport {
     lazy val dependencyMap: Map[GraphModuleId, Seq[Module]] =
       createMap(identity)
 
+    def reachableModuleIdsFrom(root: GraphModuleId): Set[GraphModuleId] = {
+      @annotation.tailrec
+      def visit(pending: List[GraphModuleId], visited: Set[GraphModuleId]): Set[GraphModuleId] =
+        pending match {
+          case Nil                                      => visited
+          case current :: remaining if visited(current) => visit(remaining, visited)
+          case current :: remaining                     =>
+            val dependencies = dependencyMap(current).map(_.id).toList
+            visit(dependencies ::: remaining, visited + current)
+        }
+
+      visit(root :: Nil, Set.empty)
+    }
+
     def createMap(
         bindingFor: ((GraphModuleId, GraphModuleId)) => (GraphModuleId, GraphModuleId)
     ): Map[GraphModuleId, Seq[Module]] = {

--- a/src/sbt-test/dependencies/internalProjectConfigurations/build.sbt
+++ b/src/sbt-test/dependencies/internalProjectConfigurations/build.sbt
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
+ThisBuild / organization := "org.example"
+ThisBuild / version := "0.1"
+ThisBuild / scalaVersion := "2.12.21"
+
+lazy val root = (project in file("."))
+  .dependsOn(compileSupport)
+  .dependsOn(testSupport % "test->test")
+  .settings(
+    name := "root",
+    bomFileName := "compile-bom.xml",
+    Test / bomFileName := "test-bom.xml",
+    includeBomToolVersion := false,
+    includeBomHashes := false,
+    includeBomExternalReferences := false,
+    check := Def
+      .sequential(
+        clean,
+        checkTask
+      )
+      .value
+  )
+
+lazy val compileSupport = (project in file("compile-support"))
+  .dependsOn(compileTransitive)
+  .settings(name := "compile-support")
+
+lazy val compileTransitive = (project in file("compile-transitive"))
+  .settings(name := "compile-transitive")
+
+lazy val testSupport = (project in file("test-support"))
+  .dependsOn(testTransitive)
+  .settings(name := "test-support")
+
+lazy val testTransitive = (project in file("test-transitive"))
+  .settings(name := "test-transitive")
+
+lazy val check = taskKey[Unit]("check")
+lazy val checkTask = Def.task {
+  val compileBom = IO.read(makeBom.value)
+  assert(compileBom.contains("compile-support"), "Compile SBOM must include compile project dependencies")
+  assert(compileBom.contains("compile-transitive"), "Compile SBOM must include transitive compile dependencies")
+  assert(!compileBom.contains("test-support"), "Compile SBOM must exclude test-only project dependencies")
+  assert(!compileBom.contains("test-transitive"), "Compile SBOM must exclude transitive test-only dependencies")
+
+  val testBom = IO.read((Test / makeBom).value)
+  assert(testBom.contains("test-support"), "Test SBOM must include test project dependencies")
+  assert(testBom.contains("test-transitive"), "Test SBOM must include transitive test dependencies")
+}

--- a/src/sbt-test/dependencies/internalProjectConfigurations/project/plugins.sbt
+++ b/src/sbt-test/dependencies/internalProjectConfigurations/project/plugins.sbt
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: The sbt-sbom team
+//
+// SPDX-License-Identifier: MIT
+
+(
+  sys.props.get("plugin.version"),
+  sys.props.get("plugin.organization")
+) match {
+  case (Some(version), Some(organization)) =>
+    addSbtPlugin(organization % "sbt-sbom" % version)
+  case (None, _) =>
+    sys.error(
+      """|The system property 'plugin.version' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+  case (_, None) =>
+    sys.error(
+      """|The system property 'plugin.organization' is not defined.
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin
+    )
+}

--- a/src/sbt-test/dependencies/internalProjectConfigurations/test
+++ b/src/sbt-test/dependencies/internalProjectConfigurations/test
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: The sbt-sbom team
+# SPDX-License-Identifier: MIT
+> check


### PR DESCRIPTION
## Motivation

Apache Pekko's published Compile SBOMs can contain test-only internal projects such as `pekko-actor-tests`, `pekko-remote-tests`, and `pekko-actor-typed-tests` as required components.

The sbt `UpdateReport` includes those test-only inter-project modules as disconnected nodes in the Compile report. `sbt-sbom` previously converted every reported module into a component, even when it was not reachable from the current project root.

## Modification

- Traverse the module graph from the current project root.
- Limit both SBOM components and dependency-tree nodes to reachable modules.
- Add scripted coverage with direct and transitive Compile/Test project dependencies.

## Result

Compile SBOMs exclude test-only project dependencies, while Test SBOMs continue to include them. The implementation is based on graph reachability and does not rely on project naming conventions.

## Tests

- JDK 17, Scala 2.12.21 / sbt 1: `scalafixAll --check`, `githubWorkflowCheck`, unit tests, and all 13 scripted tests.
- JDK 17, Scala 3.8.4 / sbt 2: `scalafixAll --check`, `githubWorkflowCheck`, unit tests, and all 13 scripted tests.
- JDK 25, both Scala/sbt variants: unit tests and `dependencies/internalProjectConfigurations` scripted test.
- Apache Pekko `persistence-testkit / makeBom` with the locally published plugin: the three reported test artifacts are absent, normal Compile dependencies remain, and every dependency reference resolves to the root or a component.

## References

- https://github.com/apache/pekko/issues/1736
