### PR TITLE
Fix warnings

### DIFF
--- a/project/Organization.scala
+++ b/project/Organization.scala
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
-import sbt.{ URI, url }
+import sbt.{ URI, uri }
 
 object Organization {
   val organization: String = "com.github.sbt"
   val organizationName: String = "sbt"
-  val organizationHomepage: Option[URI] = Some(url("https://www.scala-sbt.org/"))
+  val organizationHomepage: Option[URI] = Some(uri("https://www.scala-sbt.org/"))
 }

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -9,22 +9,22 @@ object ProjectSettings {
     "SBT plugin to generate CycloneDx SBOM files"
 
   lazy val homepage: Option[URI] =
-    Some(url("https://github.com/siculo/sbt-bom"))
+    Some(uri("https://github.com/siculo/sbt-bom"))
 
   lazy val developers: List[Developer] =
     List(
-      Developer("siculo", "Fabrizio Di Giuseppe", "siculo.github@gmail.com", url("https://github.com/siculo"))
+      Developer("siculo", "Fabrizio Di Giuseppe", "siculo.github@gmail.com", uri("https://github.com/siculo"))
     )
 
   lazy val licenses: List[License] =
     List(
-      License("MIT License", url("https://opensource.org/licenses/MIT"))
+      License("MIT License", uri("https://opensource.org/licenses/MIT"))
     )
 
   lazy val scmInfo: Option[ScmInfo] =
     Some(
       ScmInfo(
-        url("https://github.com/siculo/sbt-bom/tree/master"),
+        uri("https://github.com/siculo/sbt-bom/tree/master"),
         "scm:git:git://github.com/siculo/sbt-bom.git",
         Some("scm:git:ssh://github.com:siculo/sbt-bom.git")
       )


### PR DESCRIPTION
- https://github.com/sbt/sbt/blob/v2.0.7/sbt-app/src/main/scala/package.scala#L44-L45
- https://github.com/sbt/sbt/commit/8bac5b9a82eada867480e0937522b42b9f79390c

```
[warn] -- Deprecation Warning: /Users/runner/work/sbt-sbom/sbt-sbom/project/Organization.scala:10:47 
[warn] 10 |  val organizationHomepage: Option[URI] = Some(url("https://www.scala-sbt.org/"))
[warn]    |                                               ^^^
[warn]    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
[warn] -- Deprecation Warning: /Users/runner/work/sbt-sbom/sbt-sbom/project/ProjectSettings.scala:12:9 
[warn] 12 |    Some(url("https://github.com/siculo/sbt-bom"))
[warn]    |         ^^^
[warn]    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
[warn] -- Deprecation Warning: /Users/runner/work/sbt-sbom/sbt-sbom/project/ProjectSettings.scala:16:77 
[warn] 16 |      Developer("siculo", "Fabrizio Di Giuseppe", "siculo.github@gmail.com", url("https://github.com/siculo"))
[warn]    |                                                                             ^^^
[warn]    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
[warn] -- Deprecation Warning: /Users/runner/work/sbt-sbom/sbt-sbom/project/ProjectSettings.scala:21:29 
[warn] 21 |      License("MIT License", url("https://opensource.org/licenses/MIT"))
[warn]    |                             ^^^
[warn]    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
[warn] -- Deprecation Warning: /Users/runner/work/sbt-sbom/sbt-sbom/project/ProjectSettings.scala:27:8 
[warn] 27 |        url("https://github.com/siculo/sbt-bom/tree/master"),
[warn]    |        ^^^
[warn]    |method url in package sbt is deprecated since 2.0.2: Use uri(...) instead
[warn] 5 warnings found
```